### PR TITLE
Fixed markdown files for jekyll conversion fails and dead links

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -74,7 +74,7 @@ The [K2hQueue](k2hq_class.html) class provides the methods shown below.
 - [K2hQueue::__construct](k2hq_construct.html) - Creates a K2hQueue instance
 - [K2hQueue::count](k2hq_count.html) - Counts elements in the K2hQueue object
 - [K2hQueue::dump](k2hq_dump.html) - Prints the elements in the K2hQueue object
-- [K2hQueue::isEmpty](k2hq_isEmpty.html) - Returns whether the K2hQueue is empty
+- [K2hQueue::isEmpty](k2hq_isempty.html) - Returns whether the K2hQueue is empty
 - [K2hQueue::pop](k2hq_pop.html) - Removes and returns the removed element from the K2hQueue
 - [K2hQueue::push](k2hq_push.html) - Adds a value to the K2hQueue
 - [K2hQueue::read](k2hq_read.html) - Returns a key/value pair from the K2hQueue
@@ -87,7 +87,7 @@ The [K2hKeyQueue](k2hkq_class.html) class provides the methods shown below.
 - [K2hKeyQueue::__construct](k2hkq_construct.html) - Creates a K2hKeyQueue instance
 - [K2hKeyQueue::count](k2hkq_count.html) - Counts elements in the K2hKeyQueue object
 - [K2hKeyQueue::dump](k2hkq_dump.html) - Prints the elements in the K2hKeyQueue object
-- [K2hKeyQueue::isEmpty](k2hkq_isEmpty.html) - Returns whether the K2hKeyQueue is empty
+- [K2hKeyQueue::isEmpty](k2hkq_isempty.html) - Returns whether the K2hKeyQueue is empty
 - [K2hKeyQueue::pop](k2hkq_pop.html) - Removes and returns the removed element from the K2hKeyQueue
 - [K2hKeyQueue::push](k2hkq_push.html) - Adds a key/value pair to the K2hKeyQueue
 - [K2hKeyQueue::read](k2hkq_read.html) - Returns a key/value pair from the K2hKeyQueue

--- a/developerja.md
+++ b/developerja.md
@@ -74,7 +74,7 @@ K2hQueueクラスの説明は、[こちら](k2hq_classja.html)を参照してく
 - [K2hQueue::__construct](k2hq_constructja.html) - 新しいK2hQueueオブジェクトを作成する
 - [K2hQueue::count](k2hq_countja.html) - キューにある要素の数を取得する
 - [K2hQueue::dump](k2hq_dumpja.html) - キューにある要素を表示する
-- [K2hQueue::isEmpty](k2hq_isEmptyja.html) - キューが空かどうかを判定する
+- [K2hQueue::isEmpty](k2hq_isemptyja.html) - キューが空かどうかを判定する
 - [K2hQueue::pop](k2hq_popja.html) - キューから要素を取得する
 - [K2hQueue::push](k2hq_pushja.html) - キューに要素を追加する
 - [K2hQueue::read](k2hq_readja.html) - キューの要素を表示する
@@ -87,7 +87,7 @@ K2hKeyQueueクラスの説明は、[こちら](k2hkq_classja.html)を参照し�
 - [K2hKeyQueue::__construct](k2hkq_constructja.html) - 新しいK2hKeyQueueオブジェクトを作成する
 - [K2hKeyQueue::count](k2hkq_countja.html) - キューにある要素の数を取得する
 - [K2hKeyQueue::dump](k2hkq_dumpja.html) - キューにある要素を表示する
-- [K2hKeyQueue::isEmpty](k2hkq_isEmptyja.html) - キューが空かどうかを判定する
+- [K2hKeyQueue::isEmpty](k2hkq_isemptyja.html) - キューが空かどうかを判定する
 - [K2hKeyQueue::pop](k2hkq_popja.html) - キューから要素（キーと値のセット）を取得する
 - [K2hKeyQueue::push](k2hkq_pushja.html) - キューに要素（キーと値のセット）を追加する
 - [K2hKeyQueue::read](k2hkq_readja.html) - キューの要素（キーと値のセット）を表示する

--- a/k2h_addattr.md
+++ b/k2h_addattr.md
@@ -17,9 +17,11 @@ next_string: K2hash::addAttrCryptPass
 Adds the attribute to the key
 
 ## Description
+
 ```
 public bool K2hash::addAttr ( string $key , string $attrkey , string $attrval )
 ```
+
 Adds the attribute to the key. Attributes represent configurations to keep timestamps of data modification, data encryptions or histories. 
 
 ## Parameters
@@ -35,6 +37,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Adds an attribute and get it
+
 ```
 <?php
 
@@ -47,10 +50,13 @@ var_dump($k2hash->getAttrValue("test", "testattr"));
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 string(13) "testattrvalue"
 ```
+
 
 ## See Also
 - [K2hash::addAttrCryptPass](k2h_addattrcryptpass.html) - Adds the password to encrypt values

--- a/k2h_addattrcryptpass.md
+++ b/k2h_addattrcryptpass.md
@@ -17,9 +17,11 @@ next_string: K2hash::addAttrPluginLib
 Adds the password to encrypt values
 
 ## Description
+
 ```
 public bool K2hash::addAttrCryptPass ( string $encpass [, bool $is_default_encrypt ] )
 ```
+
 Adds the password to encrypt values. The encrption algorithm is AES256. 
 
 ## Parameters
@@ -33,6 +35,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Adds a password to encypt values
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -41,10 +44,13 @@ var_dump($k2hash->addAttrCryptPass("testkey", true));
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+
 
 ## See Also
 - [K2hash::addAttr](k2h_addattr.html) - Adds the attribute to the key

--- a/k2h_addattrcryptpassja.md
+++ b/k2h_addattrcryptpassja.md
@@ -17,9 +17,11 @@ next_string: K2hash::addAttrPluginLib
 値を暗号化するパスワード（暗号鍵）を追加する
 
 ## 説明
+
 ```
 public bool K2hash::addAttrCryptPass ( string $encpass [, bool $is_default_encrypt ] )
 ```
+
 値を暗号化するパスワードを追加します。パスワードは、AES256共通鍵として使われます。 
 
 ## パラメータ
@@ -33,6 +35,7 @@ public bool K2hash::addAttrCryptPass ( string $encpass [, bool $is_default_encry
 
 ## 例
 - 例 1 - 暗号化パスワードを追加する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -41,10 +44,13 @@ var_dump($k2hash->addAttrCryptPass("testkey", true));
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+
 
 ## 参考
 - [K2hash::addAttr](k2h_addattrja.html) - キーに属性を追加する

--- a/k2h_addattrja.md
+++ b/k2h_addattrja.md
@@ -17,9 +17,11 @@ next_string: K2hash::addAttrCryptPass
 キーに属性を追加する
 
 ## 説明
+
 ```
 public bool K2hash::addAttr ( string $key , string $attrkey , string $attrval )
 ```
+
 キーに属性を追加します。属性とは、該当キーに対する設定（更新時刻保持の有無、暗号化の有無、履歴情報保持の有無など）です。 
 
 ## パラメータ
@@ -35,6 +37,7 @@ public bool K2hash::addAttr ( string $key , string $attrkey , string $attrval )
 
 ## 例
 - 例 1 - 属性を追加し、取得する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -46,10 +49,13 @@ var_dump($k2hash->getAttrValue("test", "testattr"));
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 string(13) "testattrvalue"
 ```
+
 
 ## 参考
 - [K2hash::addAttrCryptPass](k2h_addattrcryptpassja.html) - 値を暗号化するパスワード（暗号鍵）を追加する

--- a/k2h_addattrpluginlib.md
+++ b/k2h_addattrpluginlib.md
@@ -17,9 +17,11 @@ next_string: K2hash::addSubkey
 Adds the user-defined library to handle attributes
 
 ## Description
+
 ```
 public bool K2hash::addAttrPluginLib ( string $libfile )
 ```
+
 Adds the user-defined library to handle attributes. k2hash supports for adding user-defined attributes to keys by using this method. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Adds the user-defined library to handle attributes
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -39,10 +42,13 @@ var_dump($k2hash->addAttrPluginLib("/tmp/libk2htestattr.so"));
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+
 
 ## See Also
 - [K2hash::addAttr](k2h_addattr.html) - Adds the attribute to the key

--- a/k2h_addattrpluginlibja.md
+++ b/k2h_addattrpluginlibja.md
@@ -17,9 +17,11 @@ next_string: K2hash::addSubkey
 ユーザ定義の動的ライブラリを追加する
 
 ## 説明
+
 ```
 public bool K2hash::addAttrPluginLib ( string $libfile )
 ```
+
 ユーザ定義の動的ライブラリを追加します。k2hashは、キーに対して任意の属性を付与できます。本メソッドは、ユーザ定義の動的ライブラリを追加し、キーに属性を追加します。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ public bool K2hash::addAttrPluginLib ( string $libfile )
 
 ## 例
 - 例 1 - ユーザ定義の動的ライブラリを追加する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -39,10 +42,13 @@ var_dump($k2hash->addAttrPluginLib("/tmp/libk2htestattr.so"));
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+
 
 ## 参考
 - [K2hash::addAttr](k2h_addattrja.html) - キーに属性を追加する

--- a/k2h_addsubkey.md
+++ b/k2h_addsubkey.md
@@ -17,9 +17,11 @@ next_string: K2hash::addSubkeys
 Associates the key with the other key
 
 ## Description
+
 ```
 public bool K2hash::addSubkey ( string $key , string $subkey )
 ```
+
 Associates the key with the other key. The key that is added to the other key is called 'subkey'. The key that adds the other key to is 'parent key'. A parent key can associates many subkeys.
 
 ## Parameters
@@ -33,6 +35,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Adds the subkey to the key
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -42,13 +45,16 @@ var_dump($k2hash->getSubkeys("test"));
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 array(1) {
   [0]=>
   string(3) "sub"
 }
 ```
+
 
 ## See Also
 - [K2hash::addSubkeys](k2h_addsubkeys.html) - Adds the subkeys to the key

--- a/k2h_addsubkeyja.md
+++ b/k2h_addsubkeyja.md
@@ -17,9 +17,11 @@ next_string: K2hash::addSubkeys
 キーを紐づける
 
 ## 説明
+
 ```
 public bool K2hash::addSubkey ( string $key , string $subkey )
 ```
+
 キーに他のキーを紐付けます。紐づけるキーは、紐づけられるキーの「サブキー」と呼びます。 
 
 ## パラメータ
@@ -33,6 +35,7 @@ public bool K2hash::addSubkey ( string $key , string $subkey )
 
 ## 例
 - 例 1 - サブキーを追加する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -42,13 +45,16 @@ var_dump($k2hash->getSubkeys("test"));
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 array(1) {
   [0]=>
   string(3) "sub"
 }
 ```
+
 
 ## 参考
 - [K2hash::addSubkeys](k2h_addsubkeysja.html) - 複数のキーを紐づける

--- a/k2h_addsubkeys.md
+++ b/k2h_addsubkeys.md
@@ -17,9 +17,11 @@ next_string: K2hash::cleanCommonAttribute
 Adds the subkeys to the key
 
 ## Description
+
 ```
 public bool K2hash::addSubkeys ( string $key , array $subkeys )
 ```
+
 Associates the keys with the other key. The key that is added to the other key is called 'subkey'. The key that adds the other key to is 'parent key'. A parent key can associates many subkeys. 
 
 ## Parameters
@@ -33,6 +35,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Adds subkeys to a key
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -42,7 +45,9 @@ var_dump($k2hash->getSubkeys("test"));
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 array(3) {
   [0]=>
@@ -53,6 +58,7 @@ array(3) {
   string(7) "subkey3"
 }
 ```
+
 
 ## See Also
 - [K2hash::addSubkey](k2h_addsubkey.html) - Associates the key with the other key

--- a/k2h_addsubkeysja.md
+++ b/k2h_addsubkeysja.md
@@ -17,9 +17,11 @@ next_string: K2hash::cleanCommonAttribute
 複数のキーを紐づける
 
 ## 説明
+
 ```
 public bool K2hash::addSubkeys ( string $key , array $subkeys )
 ```
+
 キーに複数のキーを紐付けます。紐づけるキーは、紐づけられるキーの「サブキー」と呼びます。 
 
 ## パラメータ
@@ -33,6 +35,7 @@ public bool K2hash::addSubkeys ( string $key , array $subkeys )
 
 ## 例
 - 例 1 - サブキーを追加する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -42,7 +45,9 @@ var_dump($k2hash->getSubkeys("test"));
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 array(3) {
   [0]=>
@@ -53,6 +58,7 @@ array(3) {
   string(7) "subkey3"
 }
 ```
+
 
 ## 参考
 - [K2hash::addSubkey](k2h_addsubkeyja.html) - キーを紐づける

--- a/k2h_class.md
+++ b/k2h_class.md
@@ -18,6 +18,7 @@ K2hash class provides methods to operation for [K2HASH](https://k2hash.antpick.a
 See each method pages for details.   
 
 ## Class overview
+
 ```
 K2hash {
     public addAttr ( string $key , string $attrkey , string $attrval ) : bool
@@ -65,6 +66,7 @@ K2hash {
     public static unsetTransactionThreadPool ( void ) : bool
 }
 ```
+
 
 ## Method list
 

--- a/k2h_classja.md
+++ b/k2h_classja.md
@@ -18,6 +18,7 @@ K2hashクラスは、[K2HASH](https://k2hash.antpick.ax/indexja.html)を操作�
 使い方は、各メソッドの説明ページを参照してください。
 
 ## Class 概要
+
 ```
 K2hash {
     public addAttr ( string $key , string $attrkey , string $attrval ) : bool
@@ -65,6 +66,7 @@ K2hash {
     public static unsetTransactionThreadPool ( void ) : bool
 }
 ```
+
 
 ## メソッド一覧
 - [K2hash::addAttr](k2h_addattrja.html) - キーに属性を追加する

--- a/k2h_cleancommonattribute.md
+++ b/k2h_cleancommonattribute.md
@@ -17,9 +17,11 @@ next_string: K2hash::close
 Initializes the common attributes
 
 ## Description
+
 ```
 public bool K2hash::cleanCommonAttribute ( void )
 ```
+
 Initializes the common attributes.
 Common attributes are:
 - mtime  
@@ -39,6 +41,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Initializes the common attribute
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -47,10 +50,13 @@ var_dump($k2hash->cleanCommonAttribute());
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+
 
 ## See Also
 - [K2hash::addAttr](k2h_addattr.html) - Adds the attribute to the key

--- a/k2h_cleancommonattributeja.md
+++ b/k2h_cleancommonattributeja.md
@@ -17,9 +17,11 @@ next_string: K2hash::close
 キーの基本属性を初期化する
 
 ## 説明
+
 ```
 public bool K2hash::cleanCommonAttribute ( void )
 ```
+
 キーの基本属性を初期化します。  
 
 基本属性は次のとおりです。  
@@ -40,6 +42,7 @@ public bool K2hash::cleanCommonAttribute ( void )
 
 ## 例
 - 例 1 - 基本属性を初期化する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -48,10 +51,13 @@ var_dump($k2hash->cleanCommonAttribute());
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+
 
 ## 参考
 - [K2hash::addAttr](k2h_addattrja.html) - キーに属性を追加する

--- a/k2h_close.md
+++ b/k2h_close.md
@@ -17,9 +17,11 @@ next_string: K2hash::create
 Closes the k2hash file
 
 ## Description
+
 ```
  public bool K2hash::close ([ int $waitms ] )
 ```
+
 Closes the k2hash (.k2h) file handle internally opened by K2hash::open and saves the data. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Closes a k2hash file
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -38,10 +41,13 @@ $k2hash->openMem();
 var_dump($k2hash->close());
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+
 
 ## See Also
 - [K2hash::open](k2h_open.html) - Opens the k2h file

--- a/k2h_closeja.md
+++ b/k2h_closeja.md
@@ -17,9 +17,11 @@ next_string: K2hash::create
 k2hashファイルを閉じる
 
 ## 説明
+
 ```
  public bool K2hash::close ([ int $waitms ] )
 ```
+
 オープンされているk2hファイルを閉じて、変更内容を保存します。
 
 ## パラメータ
@@ -31,6 +33,7 @@ k2hファイルを閉じるまでの待ち時間（単位は1/1000秒）
 
 ## 例
 - 例 1 - k2hashファイルを閉じる
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -38,10 +41,13 @@ $k2hash->openMem();
 var_dump($k2hash->close());
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+
 
 ## 参考
 - [K2hash::open](k2h_openja.html) - k2hファイルを開く

--- a/k2h_create.md
+++ b/k2h_create.md
@@ -17,9 +17,11 @@ next_string: K2hash::disableTransaction
 Creates the k2hash file
 
 ## Description
+
 ```
  public static bool K2hash::create ( string $filepath [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]] )
 ```
+
 Creates the k2hash (.k2h) file.
 
 ## Parameters
@@ -39,12 +41,16 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Creates a k2hash file
+
 ```
 <?php
 var_dump(K2hash::create("/tmp/test_k2hash.k2h"));
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+

--- a/k2h_createja.md
+++ b/k2h_createja.md
@@ -17,9 +17,11 @@ next_string: K2hash::disableTransaction
 k2hashファイルを作成する
 
 ## 説明
+
 ```
  public static bool K2hash::create ( string $filepath [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]] )
 ```
+
 k2hashファイルを作成します。 
 
 ## パラメータ
@@ -39,12 +41,16 @@ CMASKビットカウント数。この値は、キーが衝突した際に、デ
 
 ## 例
 - 例 1 - k2hashファイルを作る
+
 ```
 <?php
 var_dump(K2hash::create("/tmp/test_k2hash.k2h"));
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+

--- a/k2h_disabletransaction.md
+++ b/k2h_disabletransaction.md
@@ -17,9 +17,11 @@ next_string: K2hash::dumpElementtable
 Stops a transaction
 
 ## Description
+
 ```
  public bool K2hash::disableTransaction ( void )
 ```
+
 Stops a transaction. 
 
 ## Parameters
@@ -30,6 +32,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Stops a transaction
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -38,10 +41,13 @@ var_dump($k2hash->disableTransaction());
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+
 
 ## See Also
 - [K2hash::enableTransaction](k2h_enabletransaction.html) - Starts a transaction

--- a/k2h_disabletransactionja.md
+++ b/k2h_disabletransactionja.md
@@ -17,9 +17,11 @@ next_string: K2hash::dumpElementtable
 トランザクションを停止する
 
 ## 説明
+
 ```
  public bool K2hash::disableTransaction ( void )
 ```
+
 トランザクションを停止します。
 
 ## パラメータ
@@ -30,6 +32,7 @@ next_string: K2hash::dumpElementtable
 
 ## 例
 - 例 1 - トランザクションを停止する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -38,10 +41,13 @@ var_dump($k2hash->disableTransaction());
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+
 
 ## 参考
 - [K2hash::enableTransaction](k2h_enabletransactionja.html) - トランザクションを開始する

--- a/k2h_dumpelementtable.md
+++ b/k2h_dumpelementtable.md
@@ -17,9 +17,11 @@ next_string: K2hash::dumpFull
 Prints elements of the k2hash's hash table elements
 
 ## Description
+
 ```
  public bool K2hash::dumpElementtable ([ mixed $output ] )
 ```
+
 Prints elements of the k2hash hashtable elements including headers, hash tables and sub-hash tables. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Prints the elements of k2hash's hash tables
+
 ```
 <?php
 K2hash::create("/tmp/test_k2hash.k2h");
@@ -52,7 +55,9 @@ if ($fp) {
 }
 ?>
 ```
+
 The above example will output:
+
 ```
 ...
     Key Index Pointer[29] = Not Allocated
@@ -60,6 +65,7 @@ The above example will output:
     Key Index Pointer[31] = Not Allocated
   }
 ```
+
 
 ## See Also
 - [K2hash::dumpFull](k2h_dumpfull.html) - Prints the k2hash's hash tables in details

--- a/k2h_dumpelementtableja.md
+++ b/k2h_dumpelementtableja.md
@@ -17,9 +17,11 @@ next_string: K2hash::dumpFull
 k2hashのハッシュテーブル内部の要素などを表示する
 
 ## 説明
+
 ```
  public bool K2hash::dumpElementtable ([ mixed $output ] )
 ```
+
 k2hashのハッシュテーブル内部の要素などを表示します。k2hashのヘッダ、ハッシュテーブル、サブハッシュテーブルなども含まれます。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ k2hashのハッシュテーブル内部の要素などを表示します。k2has
 
 ## 例
 - 例 1 - ハッシュテーブルの要素などを出力する
+
 ```
 <?php
 K2hash::create("/tmp/test_k2hash.k2h");
@@ -52,7 +55,9 @@ if ($fp) {
 }
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 ...
     Key Index Pointer[29] = Not Allocated
@@ -60,6 +65,7 @@ if ($fp) {
     Key Index Pointer[31] = Not Allocated
   }
 ```
+
 
 ## 参考
 - [K2hash::dumpFull](k2h_dumpfullja.html) - k2hashのハッシュテーブル内部のデータなどを表示する

--- a/k2h_dumpfull.md
+++ b/k2h_dumpfull.md
@@ -17,9 +17,11 @@ next_string: K2hash::dumpFullKeytable
 Prints the k2hash's hash tables in details
 
 ## Description
+
 ```
  public bool K2hash::dumpFull ([ mixed $output ] )
 ```
+
 Prints the k2hash's hash tables in details including headers, hash tables and sub-hash tables. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Prints details of k2hash's hash tables
+
 ```
 <?php
 K2hash::create("/tmp/test_k2hash.k2h");
@@ -52,7 +55,9 @@ if ($fp) {
 }
 ?>
 ```
+
 The above example will output:
+
 ```
 ...
     Key Index Pointer[29] = Not Allocated
@@ -60,6 +65,7 @@ The above example will output:
     Key Index Pointer[31] = Not Allocated
   }
 ```
+
 
 ## See Also
 - [K2hash::dumpElementtable](k2h_dumpelementtable.html) - Prints elements of the k2hash's hash table elements

--- a/k2h_dumpfullja.md
+++ b/k2h_dumpfullja.md
@@ -17,9 +17,11 @@ next_string: K2hash::dumpFullKeytable
 k2hashのハッシュテーブル内部のデータなどを表示する
 
 ## 説明
+
 ```
  public bool K2hash::dumpFull ([ mixed $output ] )
 ```
+
 k2hashのハッシュテーブル内部のデータなどを表示します。k2hashのヘッダ、ハッシュテーブル、サブハッシュテーブル、テーブル内部の要素なども含まれます。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ k2hashのハッシュテーブル内部のデータなどを表示します。k2
 
 ## 例
 - 例 1 - ハッシュテーブルのデータなどを出力する
+
 ```
 <?php
 K2hash::create("/tmp/test_k2hash.k2h");
@@ -52,7 +55,9 @@ if ($fp) {
 }
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 ...
     Key Index Pointer[29] = Not Allocated
@@ -60,6 +65,7 @@ if ($fp) {
     Key Index Pointer[31] = Not Allocated
   }
 ```
+
 
 ## 参考
 - [K2hash::dumpElementtable](k2h_dumpelementtableja.html) - k2hashのハッシュテーブル内部の要素などを表示する

--- a/k2h_dumpfullkeytable.md
+++ b/k2h_dumpfullkeytable.md
@@ -17,9 +17,11 @@ next_string: K2hash::dumpHead
 Prints details of the k2hash's hash tables
 
 ## Description
+
 ```
  public bool K2hash::dumpFullKeytable ([ mixed $output ] )
 ```
+
 Prints details of the k2hash's hash tables including headers, hash tables and sub-hash tables. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Prints details of the k2hash's hash tables
+
 ```
 <?php
 K2hash::create("/tmp/test_k2hash.k2h");
@@ -52,7 +55,9 @@ if ($fp) {
 }
 ?>
 ```
+
 The above example will output:
+
 ```
 ...
     Key Index Pointer[29] = Not Allocated
@@ -60,6 +65,7 @@ The above example will output:
     Key Index Pointer[31] = Not Allocated
   }
 ```
+
 
 ## See Also
 - [K2hash::dumpElementtable](k2h_dumpelementtable.html) - Prints elements of the k2hash's hash table elements

--- a/k2h_dumpfullkeytableja.md
+++ b/k2h_dumpfullkeytableja.md
@@ -17,9 +17,11 @@ next_string: K2hash::dumpHead
 k2hashのハッシュテーブルなどを表示する
 
 ## 説明
+
 ```
  public bool K2hash::dumpFullKeytable ([ mixed $output ] )
 ```
+
 k2hashのハッシュテーブルなどを表示します。k2hashのヘッダ、ハッシュテーブル、サブハッシュテーブルなども含まれます。
 
 ## パラメータ
@@ -31,6 +33,7 @@ k2hashのハッシュテーブルなどを表示します。k2hashのヘッダ�
 
 ## 例
 - 例 1 - ハッシュテーブルなどを出力する
+
 ```
 <?php
 K2hash::create("/tmp/test_k2hash.k2h");
@@ -52,7 +55,9 @@ if ($fp) {
 }
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 ...
     Key Index Pointer[29] = Not Allocated
@@ -60,6 +65,7 @@ if ($fp) {
     Key Index Pointer[31] = Not Allocated
   }
 ```
+
 
 ## 参考
 - [K2hash::dumpElementtable](k2h_dumpelementtableja.html) - k2hashのハッシュテーブル内部の要素などを表示する

--- a/k2h_dumphead.md
+++ b/k2h_dumphead.md
@@ -17,9 +17,11 @@ next_string: K2hash::dumpKeytable
 Prints the k2hash's headers
 
 ## Description
+
 ```
  public bool K2hash::dumpHead ([ mixed $output ] )
 ```
+
  Prints the k2hash's headers. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Prints k2hash headers
+
 ```
 <?php
 K2hash::create("/tmp/test_k2hash.k2h");
@@ -52,7 +55,9 @@ if ($fp) {
 }
 ?>
 ```
+
 The above example will output:
+
 ```
 ...
   Last area update {
@@ -61,6 +66,7 @@ The above example will output:
     usec                    = 787684
   }
 ```
+
 
 ## See Also
 - [K2hash::dumpElementtable](k2h_dumpelementtable.html) - Prints elements of the k2hash's hash table elements

--- a/k2h_dumpheadja.md
+++ b/k2h_dumpheadja.md
@@ -17,9 +17,11 @@ next_string: K2hash::dumpKeytable
 k2hashのヘッダを表示する
 
 ## 説明
+
 ```
  public bool K2hash::dumpHead ([ mixed $output ] )
 ```
+
 k2hashのヘッダを表示します。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ k2hashのヘッダを表示します。
 
 ## 例
 - 例 1 - ヘッダを出力する
+
 ```
 <?php
 K2hash::create("/tmp/test_k2hash.k2h");
@@ -52,7 +55,9 @@ if ($fp) {
 }
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 ...
   Last area update {
@@ -61,6 +66,7 @@ if ($fp) {
     usec                    = 787684
   }
 ```
+
 
 ## 参考
 - [K2hash::dumpElementtable](k2h_dumpelementtableja.html) - k2hashのハッシュテーブル内部の要素などを表示する

--- a/k2h_dumpkeytable.md
+++ b/k2h_dumpkeytable.md
@@ -17,9 +17,11 @@ next_string: K2hash::enableTransaction
 Prints the k2hash's hash tables
 
 ## Description
+
 ```
  public bool K2hash::dumpKeytable ([ mixed $output ] )
 ```
+
 Prints the k2hash's hash tables including k2hash headers. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Prints the k2hash's hash tables
+
 ```
 <?php
 K2hash::create("/tmp/test_k2hash.k2h");
@@ -52,7 +55,9 @@ if ($fp) {
 }
 ?>
 ```
+
 The above example will output:
+
 ```
 ...
     Key Index Pointer[29] = Not Allocated
@@ -60,6 +65,7 @@ The above example will output:
     Key Index Pointer[31] = Not Allocated
   }
 ```
+
 
 ## See Also
 - [K2hash::dumpElementtable](k2h_dumpelementtable.html) - Prints elements of the k2hash's hash table elements

--- a/k2h_dumpkeytableja.md
+++ b/k2h_dumpkeytableja.md
@@ -17,9 +17,11 @@ next_string: K2hash::enableTransaction
 k2hashのハッシュテーブルを表示する
 
 ## 説明
+
 ```
  public bool K2hash::dumpKeytable ([ mixed $output ] )
 ```
+
 k2hashのハッシュテーブルなどを表示します。k2hashのヘッダ、ハッシュテーブルなども含まれます。
 
 ## パラメータ
@@ -31,6 +33,7 @@ k2hashのハッシュテーブルなどを表示します。k2hashのヘッダ�
 
 ## 例
 - 例 1 - ハッシュテーブルなどを出力する
+
 ```
 <?php
 K2hash::create("/tmp/test_k2hash.k2h");
@@ -52,7 +55,9 @@ if ($fp) {
 }
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 ...
     Key Index Pointer[29] = Not Allocated
@@ -60,6 +65,7 @@ if ($fp) {
     Key Index Pointer[31] = Not Allocated
   }
 ```
+
 
 ## 参考
 - [K2hash::dumpElementtable](k2h_dumpelementtableja.html) - k2hashのハッシュテーブル内部の要素などを表示する

--- a/k2h_enabletransaction.md
+++ b/k2h_enabletransaction.md
@@ -17,9 +17,11 @@ next_string: K2hash::getAttrInfos
 Starts a transaction
 
 ## Description
+
 ```
  public bool K2hash::enableTransaction ([ string $transfile [, string $prefix [, string $param [, int $expire ]]]] )
 ```
+
 Starts a transaction. 
 
 ## Parameters
@@ -37,6 +39,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Starts a transaction
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -45,10 +48,13 @@ var_dump($k2hash->enabletransaction("/tmp/test_k2h_trans", "trans_prefix_", "myp
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+
 
 ## See Also
 - [K2hash::disableTransaction](k2h_disabletransaction.html) - Stops a transaction

--- a/k2h_enabletransactionja.md
+++ b/k2h_enabletransactionja.md
@@ -17,9 +17,11 @@ next_string: K2hash::getAttrInfos
 トランザクションを開始する
 
 ## 説明
+
 ```
  public bool K2hash::enableTransaction ([ string $transfile [, string $prefix [, string $param [, int $expire ]]]] )
 ```
+
 トランザクションを開始します。
 
 ## パラメータ
@@ -37,6 +39,7 @@ next_string: K2hash::getAttrInfos
 
 ## 例
 - 例 1 - トランザクションを開始する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -45,10 +48,13 @@ var_dump($k2hash->enabletransaction("/tmp/test_k2h_trans", "trans_prefix_", "myp
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+
 
 ## 参考
 - [K2hash::disableTransaction](k2h_disabletransactionja.html) - トランザクションを停止する

--- a/k2h_getattrinfos.md
+++ b/k2h_getattrinfos.md
@@ -17,9 +17,11 @@ next_string: K2hash::getAttrs
 Prints the attribute information
 
 ## Description
+
 ```
  public bool K2hash::getAttrInfos ([ mixed $output ] )
 ```
+
 Prints the attribute information. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Prints the attributes information
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -51,10 +54,13 @@ if ($fp) {
 }
 ?>
 ```
+
 The above example will output:
+
 ```
 K2HASH attribute libraries:  K2H ATTR BUILTIN
 ```
+
 
 ## See Also
 - [K2hash::addAttr](k2h_addattr.html) - Adds the attribute to the key

--- a/k2h_getattrinfosja.md
+++ b/k2h_getattrinfosja.md
@@ -17,9 +17,11 @@ next_string: K2hash::getAttrs
 属性を取得する
 
 ## 説明
+
 ```
  public bool K2hash::getAttrInfos ([ mixed $output ] )
 ```
+
 属性を取得します。属性とは、キーに対する設定（更新時刻保持の有無、暗号化の有無、履歴情報保持の有無など）です。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ next_string: K2hash::getAttrs
 
 ## 例
 - 例 1 - 属性を追加し、取得する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -51,10 +54,13 @@ if ($fp) {
 }
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 K2HASH attribute libraries:  K2H ATTR BUILTIN
 ```
+
 
 ## 参考
 - [K2hash::addAttr](k2h_addattrja.html) - キーに属性を追加する

--- a/k2h_getattrs.md
+++ b/k2h_getattrs.md
@@ -17,9 +17,11 @@ next_string: K2hash::getAttrValue
 Gets attributes of the key
 
 ## Description
+
 ```
 public arrayfalseK2hash::getAttrs ( string $key )
 ```
+
 Gets attributes of the key. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns attributes of the key, otherwise false.
 
 ## Examples
 - Example 1 - Get attributes of a key
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -42,13 +45,16 @@ var_dump($k2hash->getAttrs("test"));
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 array(1) {
   [0]=>
   string(8) "testattr"
 }
 ```
+
 
 ## See Also
 - [K2hash::addAttr](k2h_addattr.html) - Adds the attribute to the key

--- a/k2h_getattrsja.md
+++ b/k2h_getattrsja.md
@@ -17,9 +17,11 @@ next_string: K2hash::getAttrValue
 キーに設定されている属性を取得する
 
 ## 説明
+
 ```
 public arrayfalseK2hash::getAttrs ( string $key )
 ```
+
 キーに設定されている属性を取得します。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ public arrayfalseK2hash::getAttrs ( string $key )
 
 ## 例
 - 例 1 - 属性を取得する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -42,13 +45,16 @@ var_dump($k2hash->getAttrs("test"));
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 array(1) {
   [0]=>
   string(8) "testattr"
 }
 ```
+
 
 ## 参考
 - [K2hash::addAttr](k2h_addattrja.html) - キーに属性を追加する

--- a/k2h_getattrvalue.md
+++ b/k2h_getattrvalue.md
@@ -17,9 +17,11 @@ next_string: K2hash::getAttrVersionInfos
 Gets an attribute value of the attribute key of the key
 
 ## Description
+
 ```
 public stringfalseK2hash::getAttrValue ( string $key , string $attrkey )
 ```
+
 Gets an attribute value of the attribute key of the key. 
 
 ## Parameters
@@ -33,6 +35,7 @@ Returns the value of the attribute of the key, otherwise false.
 
 ## Examples
 - Example 1 - Adds an attribute to a key and get it
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -44,10 +47,13 @@ var_dump($k2hash->getAttrValue("test", "testattr"));
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 string(13) "testattrvalue"
 ```
+
 
 ## See Also
 - [K2hash::addAttr](k2h_addattr.html) - Adds the attribute to the key

--- a/k2h_getattrvalueja.md
+++ b/k2h_getattrvalueja.md
@@ -17,9 +17,11 @@ next_string: K2hash::getAttrVersionInfos
 キーに設定されている属性値を取得する
 
 ## 説明
+
 ```
 public stringfalseK2hash::getAttrValue ( string $key , string $attrkey )
 ```
+
 キーに設定されている属性値を取得します。 
 
 ## パラメータ
@@ -33,6 +35,7 @@ public stringfalseK2hash::getAttrValue ( string $key , string $attrkey )
 
 ## 例
 - 例 1 - 属性を追加し、取得する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -44,10 +47,13 @@ var_dump($k2hash->getAttrValue("test", "testattr"));
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 string(13) "testattrvalue"
 ```
+
 
 ## 参考
 - [K2hash::addAttr](k2h_addattrja.html) - キーに属性を追加する

--- a/k2h_getattrversioninfos.md
+++ b/k2h_getattrversioninfos.md
@@ -17,9 +17,11 @@ next_string: K2hash::getIterator
 Prints the attribute library version
 
 ## Description
+
 ```
  public bool K2hash::getAttrVersionInfos ([ mixed $output ] )
 ```
+
 Prints the attribute library version. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Gets attribute version information
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -51,10 +54,13 @@ if ($fp) {
 }
 ?>
 ```
+
 The above example will output:
+
 ```
 K2HASH attribute libraries:  K2H ATTR BUILTIN
 ```
+
 
 ## See Also
 - [K2hash::addAttr](k2h_addattr.html) - Adds the attribute to the key

--- a/k2h_getattrversioninfosja.md
+++ b/k2h_getattrversioninfosja.md
@@ -17,9 +17,11 @@ next_string: K2hash::getIterator
 属性のライブラリバージョン情報を表示する
 
 ## 説明
+
 ```
  public bool K2hash::getAttrVersionInfos ([ mixed $output ] )
 ```
+
 属性のライブラリバージョン情報を表示します。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ next_string: K2hash::getIterator
 
 ## 例
 - 例 1 -  属性のライブラリバージョン情報を表示する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -51,10 +54,13 @@ if ($fp) {
 }
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 K2HASH attribute libraries:  K2H ATTR BUILTIN
 ```
+
 
 ## 参考
 - [K2hash::addAttr](k2h_addattrja.html) - キーに属性を追加する

--- a/k2h_getiterator.md
+++ b/k2h_getiterator.md
@@ -17,9 +17,11 @@ next_string: K2hash::getKeyQueue
 Gets a K2hIterator object
 
 ## Description
+
 ```
  public mixed K2hash::getIterator ( string $key )
 ```
+
 Gets a [K2hIterator](k2hiter_class.html) object that points to the first element of keys. [K2hIterator](k2hiter_class.html) is a class to handle the array of k2hash keys. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns a [K2hIterator](k2hiter_class.html) object.
 
 ## Examples
 - Example 1 - Gets a [K2hIterator](k2hiter_class.html) object
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -46,10 +49,13 @@ foreach($iterator as $val){
 echo $count;
 ?>
 ```
+
 The above example will output:
+
 ```
 3
 ```
+
 
 ## See Also
 - [K2hIterator::__construct](k2hiter_construct.html) - Creates a K2hIterator instance

--- a/k2h_getiteratorja.md
+++ b/k2h_getiteratorja.md
@@ -17,9 +17,11 @@ next_string: K2hash::getKeyQueue
 K2hIteratorオブジェクトを取得する
 
 ## 説明
+
 ```
  public mixed K2hash::getIterator ( string $key )
 ```
+
 指定されたキーを先頭にした [K2hIterator](k2hiter_classja.html) オブジェクトを取得します。 [K2hIterator](k2hiter_classja.html) は、k2hashのキーの配列へのポインタを操作するクラスです。
 
 ## パラメータ
@@ -31,6 +33,7 @@ K2hIteratorオブジェクトを取得する
 
 ## 例
 - 例 1 - [K2hIterator](k2hiter_classja.html) オブジェクトを取得する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -46,10 +49,13 @@ foreach($iterator as $val){
 echo $count;
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 3
 ```
+
 
 ## 参考
 - [K2hIterator::__construct](k2hiter_constructja.html) - 新しい K2hIterator オブジェクトを作成する

--- a/k2h_getkeyqueue.md
+++ b/k2h_getkeyqueue.md
@@ -34,4 +34,4 @@ Specifies the prefix of the [K2hKeyQueue](k2hkq_class.html).
 Gets a K2hKeyQueue object. 
 
 ## See Also
-- [K2hKeyQueue::__construct](k2hkq_constructja.html) - Creates a K2hKeyQueue instance
+- [K2hKeyQueue::__construct](k2hkq_construct.html) - Creates a K2hKeyQueue instance

--- a/k2h_getkeyqueue.md
+++ b/k2h_getkeyqueue.md
@@ -17,9 +17,11 @@ next_string: K2hash::getQueue
 Gets a K2hKeyQueue object
 
 ## Description
+
 ```
  public mixed K2hash::getKeyQueue ([ bool $is_filo [, string $prefix ]] )
 ```
+
 Gets a [K2hKeyQueue](k2hkq_class.html) object. [K2hKeyQueue](k2hkq_class.html) is a class to handle [K2hKeyQueue](k2hkq_class.html) object that holds key/value pairs as elements
 
 ## Parameters

--- a/k2h_getkeyqueueja.md
+++ b/k2h_getkeyqueueja.md
@@ -34,4 +34,4 @@ FIFO(先入先出し)キューならtrue、そうでなければ、false
 [K2hKeyQueue](k2hkq_classja.html)オブジェクト 
 
 ## 参考
-- [K2hKeyQueue::__construct](k2hkq_construct.html) - 新しいK2hKeyQueueオブジェクトを作成する
+- [K2hKeyQueue::__construct](k2hkq_constructja.html) - 新しいK2hKeyQueueオブジェクトを作成する

--- a/k2h_getkeyqueueja.md
+++ b/k2h_getkeyqueueja.md
@@ -17,9 +17,11 @@ next_string: K2hash::getQueue
 K2hKeyQueueオブジェクトを取得する
 
 ## 説明
+
 ```
  public mixed K2hash::getKeyQueue ([ bool $is_filo [, string $prefix ]] )
 ```
+
 [K2hKeyQueue](k2hkq_classja.html)オブジェクトを取得します。[K2hKeyQueue](k2hkq_classja.html)は、k2hashを利用したキューを操作するクラスです。キューには、キーと値を一つの要素として格納します。 
 
 ## パラメータ

--- a/k2h_getqueue.md
+++ b/k2h_getqueue.md
@@ -17,9 +17,11 @@ next_string: K2hash::getStream
 Gets a K2hQueue object
 
 ## Description
+
 ```
  public mixed K2hash::getQueue ([ bool $is_filo [, string $prefix ]] )
 ```
+
 Gets a [K2hQueue](k2hq_class.html) object. [K2hQueue](k2hq_class.html) is a class to handle [K2hQueue](k2hq_class.html) object that holds key/value pairs as elements. 
 
 ## Parameters

--- a/k2h_getqueueja.md
+++ b/k2h_getqueueja.md
@@ -17,9 +17,11 @@ next_string: K2hash::getStream
 K2hQueueオブジェクトを取得する
 
 ## 説明
+
 ```
  public mixed K2hash::getQueue ([ bool $is_filo [, string $prefix ]] )
 ```
+
 [K2hQueue](k2hq_classja.html)オブジェクトを取得します。[K2hQueue](k2hq_classja.html)は、k2hashを利用したキューを操作するクラスです。キューには、値を一つの要素として格納します。 
 
 ## パラメータ

--- a/k2h_getstream.md
+++ b/k2h_getstream.md
@@ -17,9 +17,11 @@ next_string: K2hash::getSubkeys
 Gets a k2hash file stream
 
 ## Description
+
 ```
  public mixed K2hash::getStream ( string $key , string $mode )
 ```
+
 Gets a k2hash file stream. 
 
 ## Parameters
@@ -33,6 +35,7 @@ Returns a h2hash file stream.
 
 ## Examples
 - Example 1 - Gets value using the k2hash file stream
+
 ```
 <?php
 K2hash::create("/tmp/test_k2hash.k2h");
@@ -50,7 +53,10 @@ fclose($stream);
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 string(6) "value1"
 ```
+

--- a/k2h_getstreamja.md
+++ b/k2h_getstreamja.md
@@ -17,9 +17,11 @@ next_string: K2hash::getSubkeys
 k2hashファイルストリームを取得する
 
 ## 説明
+
 ```
  public mixed K2hash::getStream ( string $key , string $mode )
 ```
+
 指定されたキーを先頭にしたk2hashファイルストリームを取得します。 
 
 ## パラメータ
@@ -33,6 +35,7 @@ k2hashファイルストリーム
 
 ## 例
 - 例 1 - キーへのストリームを操作する
+
 ```
 <?php
 K2hash::create("/tmp/test_k2hash.k2h");
@@ -50,7 +53,10 @@ fclose($stream);
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 string(6) "value1"
 ```
+

--- a/k2h_getsubkeys.md
+++ b/k2h_getsubkeys.md
@@ -17,9 +17,11 @@ next_string: K2hash::getTransactionThreadPool
 Gets an array of keys associated with the key
 
 ## Description
+
 ```
 public arrayfalseK2hash::getSubkeys ( string $key [, bool $attrcheck ] )
 ```
+
 Gets an array of the keys associated with the key. 
 
 ## Parameters
@@ -33,6 +35,7 @@ Returns an array of keys associated with the key.
 
 ## Examples
 - Example 1 - Gets an array of keys associated with a key
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -42,7 +45,9 @@ var_dump($k2hash->getSubkeys("test"));
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 array(3) {
   [0]=>
@@ -53,6 +58,7 @@ array(3) {
   string(7) "subkey3"
 }
 ```
+
 
 ## See Also
 - [K2hash::addSubkey](k2h_addsubkey.html) - Associates the key with the other key

--- a/k2h_getsubkeysja.md
+++ b/k2h_getsubkeysja.md
@@ -17,9 +17,11 @@ next_string: K2hash::getTransactionThreadPool
 キーに紐づけられたキー（サブキー）の一覧を取得する
 
 ## 説明
+
 ```
 public arrayfalseK2hash::getSubkeys ( string $key [, bool $attrcheck ] )
 ```
+
 キーに紐づけられたキー（サブキー）の一覧を取得します。 
 
 ## パラメータ
@@ -33,6 +35,7 @@ public arrayfalseK2hash::getSubkeys ( string $key [, bool $attrcheck ] )
 
 ## 例
 - 例 1 - サブキーの一覧を取得する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -42,7 +45,9 @@ var_dump($k2hash->getSubkeys("test"));
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 array(3) {
   [0]=>
@@ -53,6 +58,7 @@ array(3) {
   string(7) "subkey3"
 }
 ```
+
 
 ## 参考
 - [K2hash::addSubkey](k2h_addsubkeyja.html) - キーを紐づける

--- a/k2h_gettransactionthreadpool.md
+++ b/k2h_gettransactionthreadpool.md
@@ -17,9 +17,11 @@ next_string: K2hash::getValue
 Gets the number of transaction workers
 
 ## Description
+
 ```
  public static int K2hash::getTransactionThreadPool ( void )
 ```
+
 Gets the number of transaction workers. 
 
 ## Parameters
@@ -30,15 +32,19 @@ Returns the number of transaction workers
 
 ## Examples
 - Example 1 - Gets the number of transaction workers
+
 ```
 <?php
 var_dump(K2hash::gettransactionThreadPool());
 ?>
 ```
+
 The above example will output:
+
 ```
 int(0)
 ```
+
 
 ## See Also
 - [K2hash::setTransactionThreadPool](k2h_settransactionthreadpool.html) - Sets the number of transaction workers

--- a/k2h_gettransactionthreadpoolja.md
+++ b/k2h_gettransactionthreadpoolja.md
@@ -17,9 +17,11 @@ next_string: K2hash::getValue
 トランザクション処理用のスレッド数を取得する
 
 ## 説明
+
 ```
  public static int K2hash::getTransactionThreadPool ( void )
 ```
+
 トランザクション処理用のスレッド数を取得します。 
 
 ## パラメータ
@@ -30,15 +32,19 @@ next_string: K2hash::getValue
 
 ## 例
 - 例 1 - トランザクション処理用スレッド数を取得する
+
 ```
 <?php
 var_dump(K2hash::gettransactionThreadPool());
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 int(0)
 ```
+
 
 ## 参考
 - [K2hash::setTransactionThreadPool](k2h_settransactionthreadpoolja.html) - トランザクション処理用のスレッド数を設定する

--- a/k2h_getvalue.md
+++ b/k2h_getvalue.md
@@ -17,9 +17,11 @@ next_string: K2hash::loadArchive
 Gets the value associated with the key
 
 ## Description
+
 ```
 public stringfalseK2hash::getValue ( string $key [, string $subkey [, bool $attrcheck [, string $pass ]]] )
 ```
+
 Gets the value associated with the key. Gets the keys linked with the key if the key is passed. 
 
 ## Parameters
@@ -37,6 +39,7 @@ Returns the value of the key or the subkey, otherwise false.
 
 ## Examples
 - Example 1 - Get value associated with a key
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -46,10 +49,13 @@ var_dump($k2hash->getValue("key1"));
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 string(6) "value1"
 ```
+
 
 ## See Also
 - [K2hash::setValue](k2h_setvalue.html) - Sets the value associated with the key

--- a/k2h_getvalueja.md
+++ b/k2h_getvalueja.md
@@ -17,9 +17,11 @@ next_string: K2hash::loadArchive
 値を取得する
 
 ## 説明
+
 ```
 public stringfalseK2hash::getValue ( string $key [, string $subkey [, bool $attrcheck [, string $pass ]]] )
 ```
+
 キーの値を取得します。キーと紐づけられたキー（サブキー）が指定された場合は、サブキーの値を取得します。 
 
 ## パラメータ
@@ -37,6 +39,7 @@ public stringfalseK2hash::getValue ( string $key [, string $subkey [, bool $attr
 
 ## 例
 - 例 1 - 値を取得する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -46,10 +49,13 @@ var_dump($k2hash->getValue("key1"));
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 string(6) "value1"
 ```
+
 
 ## 参考
 - [K2hash::setValue](k2h_setvalueja.html) - キーに値を設定する

--- a/k2h_loadarchive.md
+++ b/k2h_loadarchive.md
@@ -17,9 +17,11 @@ next_string: K2hash::open
 Loads data from the file
 
 ## Description
+
 ```
  public bool K2hash::loadArchive ( string $filepath [, bool $errskip ] )
 ```
+
 Loads data from the file. The file should be either a transaction file or an archive file. 
 
 ## Parameters
@@ -33,6 +35,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Creates an archive file and loads it
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -48,11 +51,14 @@ var_dump($k2hash2->getValue("key1"));
 $k2hash2->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 string(6) "value1"
 ```
+
 
 ## See Also
 - [K2hash::enableTransaction](k2h_enabletransaction.html) - Starts a transaction

--- a/k2h_loadarchiveja.md
+++ b/k2h_loadarchiveja.md
@@ -17,9 +17,11 @@ next_string: K2hash::open
 ファイルからデータをロードする
 
 ## 説明
+
 ```
  public bool K2hash::loadArchive ( string $filepath [, bool $errskip ] )
 ```
+
 トランザクションファイルまたはアーカイブファイルからデータをロードします。 
 
 ## パラメータ
@@ -33,6 +35,7 @@ next_string: K2hash::open
 
 ## 例
 - 例 1 - アーカイブファイルの作成とロード
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -48,11 +51,14 @@ var_dump($k2hash2->getValue("key1"));
 $k2hash2->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 string(6) "value1"
 ```
+
 
 ## 参考
 - [K2hash::enableTransaction](k2h_enabletransactionja.html) - トランザクションを開始する

--- a/k2h_open.md
+++ b/k2h_open.md
@@ -17,9 +17,11 @@ next_string: K2hash::openMem
 Opens the k2h file
 
 ## Description
+
 ```
  public bool K2hash::open ( string $filepath , bool $readonly [, bool $removefile [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]]] )
 ```
+
 Opens the k2hash (`.k2h`) file with read and write access. 
 
 ## Parameters

--- a/k2h_openja.md
+++ b/k2h_openja.md
@@ -17,9 +17,11 @@ next_string: K2hash::openMem
 k2hashファイルを開く
 
 ## 説明
+
 ```
  public bool K2hash::open ( string $filepath , bool $readonly [, bool $removefile [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]]] )
 ```
+
 k2hashファイルを開きます。 
 
 ## パラメータ

--- a/k2h_openmem.md
+++ b/k2h_openmem.md
@@ -17,9 +17,11 @@ next_string: K2hash::openRO
 Open k2hash as volatile(on memory).
 
 ## Description
+
 ```
  public bool K2hash::openMem ([ int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]] )
 ```
+
 Open k2hash as volatile(on memory).
 
 ## Parameters

--- a/k2h_openmemja.md
+++ b/k2h_openmemja.md
@@ -17,9 +17,11 @@ next_string: K2hash::openRO
 揮発性（メモリ）としてk2hashをオープンします。
 
 ## 説明
+
 ```
  public bool K2hash::openMem ([ int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]] )
 ```
+
 揮発性（メモリ）としてk2hashをオープンします。
 
 ## パラメータ

--- a/k2h_openro.md
+++ b/k2h_openro.md
@@ -17,9 +17,11 @@ next_string: K2hash::openRW
 Read the k2hash file
 
 ## Description
+
 ```
  public bool K2hash::openRO ( string $filepath [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]] )
 ```
+
 Opens the the k2hash (.k2h) file with read only access. 
 
 ## Parameters

--- a/k2h_openroja.md
+++ b/k2h_openroja.md
@@ -17,9 +17,11 @@ next_string: K2hash::openRW
 k2hashファイルを 読み込む
 
 ## 説明
+
 ```
  public bool K2hash::openRO ( string $filepath [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]] )
 ```
+
 読み取り専用でk2hファイルを開きます。 
 
 ## パラメータ

--- a/k2h_openrw.md
+++ b/k2h_openrw.md
@@ -17,9 +17,11 @@ next_string: K2hash::openTempfile
 Open for editing the k2hash file
 
 ## Description
+
 ```
  public bool K2hash::openRW ( string $filepath [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]] )
 ```
+
 Opens the the k2hash (`.k2h`) file with read and write access. 
 
 ## Parameters

--- a/k2h_openrwja.md
+++ b/k2h_openrwja.md
@@ -17,9 +17,11 @@ next_string: K2hash::openTempfile
 k2hashファイルを編集するためにオープンする
 
 ## 説明
+
 ```
  public bool K2hash::openRW ( string $filepath [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]] )
 ```
+
 編集可能な状態でk2hashファイルを開きます。 
 
 ## パラメータ

--- a/k2h_opentempfile.md
+++ b/k2h_opentempfile.md
@@ -17,9 +17,11 @@ next_string: K2hash::printState
 Edit the k2hash file on temporary file system
 
 ## Description
+
 ```
  public bool K2hash::openTempfile ( string $filepath [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]] )
 ```
+
 Opens the the k2hash (`.k2h`) file with read and write access on a temporary file system. 
 
 ## Parameters

--- a/k2h_opentempfileja.md
+++ b/k2h_opentempfileja.md
@@ -17,9 +17,11 @@ next_string: K2hash::printState
 一時ファイルとしてk2hashファイルを編集する
 
 ## 説明
+
 ```
  public bool K2hash::openTempfile ( string $filepath [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]] )
 ```
+
 一時ファイルとして、k2hashファイルを開きます。 
 
 ## パラメータ

--- a/k2h_printstate.md
+++ b/k2h_printstate.md
@@ -17,9 +17,11 @@ next_string: K2hash::printVersion
 Prints k2hash data statistics
 
 ## Description
+
 ```
  public bool K2hash::printState ([ mixed $output ] )
 ```
+
 Prints k2hash data statistics. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Prints k2hash data statistics
+
 ```
 <?php
 K2hash::create("/tmp/test_k2hash.k2h");
@@ -52,7 +55,9 @@ if ($fp) {
 }
 ?>
 ```
+
 The above example will output:
+
 ```
 ...
 
@@ -62,3 +67,4 @@ Total real data size    = 133431296 byte
 real data ratio         = 98 %
 }
 ```
+

--- a/k2h_printstateja.md
+++ b/k2h_printstateja.md
@@ -17,9 +17,11 @@ next_string: K2hash::printVersion
 k2hashのデータの状態を表示する
 
 ## 説明
+
 ```
  public bool K2hash::printState ([ mixed $output ] )
 ```
+
 k2hashのデータの状態を表示します。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ k2hashのデータの状態を表示します。
 
 ## 例
 - 例 1 - k2hash データの状態を出力する
+
 ```
 <?php
 K2hash::create("/tmp/test_k2hash.k2h");
@@ -52,7 +55,9 @@ if ($fp) {
 }
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 ...
 
@@ -62,3 +67,4 @@ Total real data size    = 133431296 byte
 real data ratio         = 98 %
 }
 ```
+

--- a/k2h_printversion.md
+++ b/k2h_printversion.md
@@ -17,9 +17,11 @@ next_string: K2hash::putArchive
 Prints the k2hash library version
 
 ## Description
+
 ```
  public static bool K2hash::printVersion ([ mixed $output ] )
 ```
+
 Prints the k2hash library version. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure
 
 ## Examples
 - Example 1 - Prints the library version
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -49,7 +52,9 @@ if ($fp) {
 }
 ?>
 ```
+
 The above example will output:
+
 ```
 K2HASH library Version 1.0.83 (commit: 143975d) with NSS
 
@@ -69,3 +74,4 @@ Copyright(C) 2015 Yahoo Japan Corporation.
 FULLOCK is fast locking library on user level by Yahoo! JAPAN.
 FULLOCK is following specifications.
 ```
+

--- a/k2h_printversionja.md
+++ b/k2h_printversionja.md
@@ -17,9 +17,11 @@ next_string: K2hash::putArchive
 ライブラリのバージョンなどを表示する
 
 ## 説明
+
 ```
  public static bool K2hash::printVersion ([ mixed $output ] )
 ```
+
 k2hashライブラリのバージョンおよびクレジットを表示します。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ k2hashライブラリのバージョンおよびクレジットを表示しま�
 
 ## 例
 - 例 1 - k2hash バージョンを表示する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -49,7 +52,9 @@ if ($fp) {
 }
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 K2HASH library Version 1.0.83 (commit: 143975d) with NSS
 
@@ -69,3 +74,4 @@ Copyright(C) 2015 Yahoo Japan Corporation.
 FULLOCK is fast locking library on user level by Yahoo! JAPAN.
 FULLOCK is following specifications.
 ```
+

--- a/k2h_putarchive.md
+++ b/k2h_putarchive.md
@@ -17,9 +17,11 @@ next_string: K2hash::remove
 Saves data as the archive file
 
 ## Description
+
 ```
  public bool K2hash::putArchive ( string $filepath [, bool $errskip ] )
 ```
+
 Saves the k2hash (`.k2h`) file as an archive file. 
 
 ## Parameters
@@ -33,6 +35,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Saves data as the archive file
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -48,11 +51,14 @@ var_dump($k2hash2->getValue("key1"));
 $k2hash2->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 string(6) "value1"
 ```
+
 
 ## See Also
 - [K2hash::loadArchive](k2h_loadarchive.html) - Loads data from the file

--- a/k2h_putarchiveja.md
+++ b/k2h_putarchiveja.md
@@ -17,9 +17,11 @@ next_string: K2hash::remove
 k2hashファイルをアーカイブファイルとして保存する
 
 ## 説明
+
 ```
  public bool K2hash::putArchive ( string $filepath [, bool $errskip ] )
 ```
+
 k2hashファイルをアーカイブファイルとして保存します。 
 
 ## パラメータ
@@ -33,6 +35,7 @@ k2hashファイルをアーカイブファイルとして保存します。
 
 ## 例
 - 例 1 - アーカイブファイルの作成とロード
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -48,11 +51,14 @@ var_dump($k2hash2->getValue("key1"));
 $k2hash2->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 string(6) "value1"
 ```
+
 
 ## 参考
 - [K2hash::loadArchive](k2h_loadarchiveja.html) - ファイルからデータをロードする

--- a/k2h_remove.md
+++ b/k2h_remove.md
@@ -17,9 +17,11 @@ next_string: K2hash::removeAll
 Removes the key
 
 ## Description
+
 ```
  public bool K2hash::remove ( string $key [, string $subkey ] )
 ```
+
 Removes the key. 
 
 ## Parameters
@@ -33,6 +35,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Removes the key
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -46,13 +49,17 @@ var_dump($k2hash->getValue("test1"));
 var_dump($k2hash->getValue("sub1"));
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(false)
 string(9) "sub-value"
 ```
 
+
 - Example 2 - Remove the keys linked with a key
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -65,11 +72,14 @@ var_dump($k2hash->getValue("test1"));
 var_dump($k2hash->getValue("sub1"));
 ?>
 ```
+
 The above example will output:
+
 ```
 string(5) "value"
 bool(false)
 ```
+
 
 ## See Also
 - [K2hash::removeAll](k2h_removeall.html) - Removes the key and the keys associated with the key

--- a/k2h_removeall.md
+++ b/k2h_removeall.md
@@ -17,9 +17,11 @@ next_string: K2hash::rename
 Removes the key and the keys associated with the key
 
 ## Description
+
 ```
  public bool K2hash::removeAll ( string $key )
 ```
+
 Removes the key and the keys associated with the key. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Remove the key
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -44,11 +47,14 @@ var_dump($k2hash->getValue("test1"));
 var_dump($k2hash->getValue("sub1"));
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(false)
 bool(false)
 ```
+
 
 ## See Also
 - [K2hash::remove](k2h_remove.html) - Removes the key

--- a/k2h_removeallja.md
+++ b/k2h_removeallja.md
@@ -17,9 +17,11 @@ next_string: K2hash::rename
 キーと、キーに紐づけられているキー（サブキー）を削除する
 
 ## 説明
+
 ```
  public bool K2hash::removeAll ( string $key )
 ```
+
 キーと、キーに紐づけられているキー（サブキー）を削除します。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ next_string: K2hash::rename
 
 ## 例
 - 例 1 - 親キーを削除する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -44,11 +47,14 @@ var_dump($k2hash->getValue("test1"));
 var_dump($k2hash->getValue("sub1"));
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(false)
 bool(false)
 ```
+
 
 ## 参考
 - [K2hash::remove](k2h_removeja.html) - キーを削除する

--- a/k2h_removeja.md
+++ b/k2h_removeja.md
@@ -17,9 +17,11 @@ next_string: K2hash::removeAll
 キーを削除する
 
 ## 説明
+
 ```
  public bool K2hash::remove ( string $key [, string $subkey ] )
 ```
+
 キーを削除します。キーに紐づけられたキーをサブキーと呼びます。サブキーに紐づけられたキーを親キーと呼びます。  
 親キーのみを指定した場合は、サブキーは削除されません。  
 サブキーを指定した場合は、サブキーは削除され、親キーは削除されません。  
@@ -35,6 +37,7 @@ next_string: K2hash::removeAll
 
 ## 例
 - 例 1 - 親キーを削除する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -48,13 +51,17 @@ var_dump($k2hash->getValue("test1"));
 var_dump($k2hash->getValue("sub1"));
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(false)
 string(9) "sub-value"
 ```
 
+
 - 例 2 - キー（親キー）に紐づけられたキー（サブキー）を削除する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -68,11 +75,14 @@ var_dump($k2hash->getValue("test1"));
 var_dump($k2hash->getValue("sub1"));
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 string(5) "value"
 bool(false)
 ```
+
 
 ## 参考
 - [K2hash::removeAll](k2h_removeallja.html) - キーと、キーに紐づけられているキー（サブキー）を削除する

--- a/k2h_rename.md
+++ b/k2h_rename.md
@@ -17,9 +17,11 @@ next_string: K2hash::setCommonAttribute
 Renames the key
 
 ## Description
+
 ```
  public bool K2hash::rename ( string $key , string $newkey )
 ```
+
 Renames the key
 
 ## Parameters
@@ -33,6 +35,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Renames a key
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -42,11 +45,14 @@ var_dump($k2hash->rename("test1", "test2"));
 var_dump($k2hash->getValue("test2"));
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 string(5) "value"
 ```
+
 
 ## See Also
 - [K2hash::getValue](k2h_getvalue.html) - Gets the value associated with the key

--- a/k2h_renameja.md
+++ b/k2h_renameja.md
@@ -17,9 +17,11 @@ next_string: K2hash::setCommonAttribute
 キー名を変更する
 
 ## 説明
+
 ```
  public bool K2hash::rename ( string $key , string $newkey )
 ```
+
 キー名を変更します。 
 
 ## パラメータ
@@ -33,6 +35,7 @@ next_string: K2hash::setCommonAttribute
 
 ## 例
 - 例 1 - キー名を変更する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -42,11 +45,14 @@ var_dump($k2hash->rename("test1", "test2"));
 var_dump($k2hash->getValue("test2"));
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 string(5) "value"
 ```
+
 
 ## 参考
 - [K2hash::getValue](k2h_getvalueja.html) - 値を取得する

--- a/k2h_setcommonattribute.md
+++ b/k2h_setcommonattribute.md
@@ -17,9 +17,11 @@ next_string: K2hash::setTransactionThreadPool
 Sets the common attributes
 
 ## Description
+
 ```
  public bool K2hash::setCommonAttribute ([ int $is_mtime [, int $is_history [, int $is_encrypt [, string $passfile [, int $is_expire [, int $expire ]]]]]] )
 ```
+
 Sets the common attributes. See the attributes in the parameters section. 
 
 ## Parameters
@@ -41,6 +43,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Sets the common attributes
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -49,10 +52,13 @@ var_dump($k2hash->setCommonAttribute(K2H_ATTR_ENABLE, K2H_ATTR_ENABLE, K2H_ATTR_
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+
 
 ## See Also
 - [K2hash::addAttr](k2h_addattr.html) - Adds the attribute to the key

--- a/k2h_setcommonattributeja.md
+++ b/k2h_setcommonattributeja.md
@@ -17,9 +17,11 @@ next_string: K2hash::setTransactionThreadPool
 キーの基本属性を設定する
 
 ## 説明
+
 ```
  public bool K2hash::setCommonAttribute ([ int $is_mtime [, int $is_history [, int $is_encrypt [, string $passfile [, int $is_expire [, int $expire ]]]]]] )
 ```
+
 キーの基本属性を設定します。 
 
 ## パラメータ
@@ -41,6 +43,7 @@ next_string: K2hash::setTransactionThreadPool
 
 ## 例
 - 例 1 - 基本属性を設定する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -49,10 +52,13 @@ var_dump($k2hash->setCommonAttribute(K2H_ATTR_ENABLE, K2H_ATTR_ENABLE, K2H_ATTR_
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+
 
 ## 参考
 - [K2hash::addAttr](k2h_addattrja.html) - キーに属性を追加する

--- a/k2h_settransactionthreadpool.md
+++ b/k2h_settransactionthreadpool.md
@@ -17,9 +17,11 @@ next_string: K2hash::setValue
 Sets the number of transaction workers
 
 ## Description
+
 ```
  public static bool K2hash::setTransactionThreadPool ( int $count )
 ```
+
 Sets the number of transaction workers.
 
 ## Parameters
@@ -31,17 +33,21 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Specifies the number of transaction workers
+
 ```
 <?php
 var_dump(K2hash::settransactionThreadPool(1));
 var_dump(K2hash::gettransactionThreadPool());
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 int(1)
 ```
+
 
 ## See Also
 - [K2hash::getTransactionThreadPool](k2h_gettransactionthreadpool.html) - Gets the number of transaction workers

--- a/k2h_settransactionthreadpoolja.md
+++ b/k2h_settransactionthreadpoolja.md
@@ -17,9 +17,11 @@ next_string: K2hash::setValue
 トランザクション処理用のスレッド数を設定する
 
 ## 説明
+
 ```
  public static bool K2hash::setTransactionThreadPool ( int $count )
 ```
+
 トランザクション処理用のスレッド数を設定します。 
 
 ## パラメータ
@@ -31,17 +33,21 @@ next_string: K2hash::setValue
 
 ## 例
 - 例 1 - トランザクション処理用のスレッド数を設定する
+
 ```
 <?php
 var_dump(K2hash::settransactionThreadPool(1));
 var_dump(K2hash::gettransactionThreadPool());
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 int(1)
 ```
+
 
 ## 参考
 - [K2hash::getTransactionThreadPool](k2h_gettransactionthreadpoolja.html) - トランザクション処理用のスレッド数を取得する

--- a/k2h_setvalue.md
+++ b/k2h_setvalue.md
@@ -17,9 +17,11 @@ next_string: K2hash::transaction
 Sets the value associated with the key
 
 ## Description
+
 ```
  public bool K2hash::setValue ( string $key , string $value [, string $subkey [, string $pass [, int $expire ]]] )
 ```
+
 Sets the value associated with the key. 
 
 ## Parameters
@@ -39,6 +41,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Sets a value to a key
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -48,10 +51,13 @@ var_dump($k2hash->getValue("key1"));
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 string(6) "value1"
 ```
+
 
 ## See Also
 - [K2hash::getValue](k2h_getvalue.html) - Gets the value associated with the key

--- a/k2h_setvalueja.md
+++ b/k2h_setvalueja.md
@@ -17,9 +17,11 @@ next_string: K2hash::transaction
 キーに値を設定する
 
 ## 説明
+
 ```
  public bool K2hash::setValue ( string $key , string $value [, string $subkey [, string $pass [, int $expire ]]] )
 ```
+
 キーに値を設定します。
 
 ## パラメータ
@@ -39,6 +41,7 @@ next_string: K2hash::transaction
 
 ## 例
 - 例 1 - キーに値を設定する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -48,10 +51,13 @@ var_dump($k2hash->getValue("key1"));
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 string(6) "value1"
 ```
+
 
 ## 参考
 - [K2hash::getValue](k2h_getvalueja.html) - 値を取得する

--- a/k2h_transaction.md
+++ b/k2h_transaction.md
@@ -17,9 +17,11 @@ next_string: K2hash::unsetTransactionThreadPool
 Changes transaction settings
 
 ## Description
+
 ```
  public bool K2hash::transaction ( bool $enable [, string $transfile [, string $prefix [, string $param [, int $expire ]]]] )
 ```
+
 Changes transaction settings. 
 
 ## Parameters
@@ -39,6 +41,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Starts transaction
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -47,10 +50,13 @@ var_dump($k2hash->transaction(true, "/tmp/test_k2h_trans", "trans_prefix_", "myp
 $k2hash->close();
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+
 
 ## See Also
 - [K2hash::disableTransaction](k2h_disabletransaction.html) - Stops a transaction

--- a/k2h_transactionja.md
+++ b/k2h_transactionja.md
@@ -17,9 +17,11 @@ next_string: K2hash::unsetTransactionThreadPool
 トランザクションを有効また無効にする
 
 ## 説明
+
 ```
  public bool K2hash::transaction ( bool $enable [, string $transfile [, string $prefix [, string $param [, int $expire ]]]] )
 ```
+
 トランザクションを有効または無効にします。 
 
 ## パラメータ
@@ -39,6 +41,7 @@ next_string: K2hash::unsetTransactionThreadPool
 
 ## 例
 - 例 1 - トランザクションを開始する
+
 ```
 <?php
 $k2hash = new K2hash();
@@ -47,10 +50,13 @@ var_dump($k2hash->transaction(true, "/tmp/test_k2h_trans", "trans_prefix_", "myp
 $k2hash->close();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+
 
 ## 参考
 - [K2hash::disableTransaction](k2h_disabletransactionja.html) - トランザクションを停止する

--- a/k2h_unsettransactionthreadpool.md
+++ b/k2h_unsettransactionthreadpool.md
@@ -17,9 +17,11 @@ next_string:
 Stops transaction workers
 
 ## Description
+
 ```
  public static bool K2hash::unsetTransactionThreadPool ( void )
 ```
+
 Stops transaction workers. 
 
 ## Parameters
@@ -30,6 +32,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Sets the number of transaction workers
+
 ```
 <?php
 var_dump(K2hash::settransactionThreadPool(1));
@@ -37,12 +40,15 @@ var_dump(K2hash::gettransactionThreadPool());
 var_dump(K2hash::unsettransactionThreadPool());
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 int(1)
 bool(true)
 ```
+
 
 ## See Also
 - [K2hash::getTransactionThreadPool](k2h_gettransactionthreadpool.html) - Gets the number of transaction workers

--- a/k2h_unsettransactionthreadpoolja.md
+++ b/k2h_unsettransactionthreadpoolja.md
@@ -17,9 +17,11 @@ next_string:
 トランザクション処理用のスレッドを利用しない
 
 ## 説明
+
 ```
  public static bool K2hash::unsetTransactionThreadPool ( void )
 ```
+
 トランザクション処理用のスレッドを利用しません。 
 
 ## パラメータ
@@ -30,6 +32,7 @@ next_string:
 
 ## 例
 - 例 1 - トランザクション処理用のスレッド数を設定する
+
 ```
 <?php
 var_dump(K2hash::settransactionThreadPool(1));
@@ -37,12 +40,15 @@ var_dump(K2hash::gettransactionThreadPool());
 var_dump(K2hash::unsettransactionThreadPool());
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 int(1)
 bool(true)
 ```
+
 
 ## 参考
 - [K2hash::getTransactionThreadPool](k2h_gettransactionthreadpoolja.html) - トランザクション処理用のスレッド数を取得する

--- a/k2hiter_class.md
+++ b/k2hiter_class.md
@@ -17,6 +17,7 @@ next_string: k2hash Functions
 K2hIterator represents a pointer of an array of [K2HASH](https://k2hash.antpick.ax/) keys.  
 
 ## Class overview
+
 ```
 K2hIterator implements Iterator {
     public stringfalsecurrent ( void )
@@ -26,6 +27,7 @@ K2hIterator implements Iterator {
     public valid ( void ) : bool
 }
 ```
+
 
 ## Method list
 

--- a/k2hiter_classja.md
+++ b/k2hiter_classja.md
@@ -17,6 +17,7 @@ next_string: k2hash Functions
 K2hIteratorは、[K2HASH](https://k2hash.antpick.ax/indexja.html)のキーの配列へのポインタを操作するクラスです。   
 
 ## Class 概要
+
 ```
 K2hIterator implements Iterator {
     public stringfalsecurrent ( void )
@@ -26,6 +27,7 @@ K2hIterator implements Iterator {
     public valid ( void ) : bool
 }
 ```
+
 
 ## メソッド一覧
 

--- a/k2hiter_construct.md
+++ b/k2hiter_construct.md
@@ -17,9 +17,11 @@ next_string: K2hIterator::current
 Creates a K2hIterator instance
 
 ## Description
+
 ```
 public K2hIterator::__construct ( mixed $handle_res [, string $key ] )
 ```
+
 Creates a [K2hIterator](k2hiter_class.html) instance. [K2hIterator](k2hiter_class.html) represents a pointer of an array of k2hash keys. 
 
 ## Parameters
@@ -30,6 +32,7 @@ Specifies the key to search for.
 
 ## Examples
 - Example 1 - Gets a [K2hIterator](k2hiter_class.html) instance
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,11 +47,14 @@ var_dump($k2hiter->key());
 unset($k2hiter);
 ?>
 ```
+
 The above example will output:
+
 ```
 string(5) "test1"
 string(3) "sub"
 ```
+
 
 ## See Also
 - [K2hash::getIterator](k2h_getiterator.html) - Gets a K2hIterator object

--- a/k2hiter_constructja.md
+++ b/k2hiter_constructja.md
@@ -17,9 +17,11 @@ next_string: K2hIterator::current
 新しい K2hIterator オブジェクトを作成する
 
 ## 説明
+
 ```
 public K2hIterator::__construct ( mixed $handle_res [, string $key ] )
 ```
+
 新しい [K2hIterator](k2hiter_classja.html) オブジェクトを作成します。このオブジェクトは、k2hashのキーの配列へのポインタです。 
 
 ## パラメータ
@@ -30,6 +32,7 @@ k2hファイルハンドル
 
 ## 例
 - 例 1 - [K2hIterator](k2hiter_classja.html)を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,11 +47,14 @@ var_dump($k2hiter->key());
 unset($k2hiter);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 string(5) "test1"
 string(3) "sub"
 ```
+
 
 ## 参考
 - [K2hash::getIterator](k2h_getiteratorja.html) - K2hIteratorオブジェクトを取得する

--- a/k2hiter_current.md
+++ b/k2hiter_current.md
@@ -17,9 +17,11 @@ next_string: K2hIterator::key
 Gets value of the current K2hIterator item
 
 ## Description
+
 ```
 public stringfalseK2hIterator::current ( void )
 ```
+
 Gets the value of the current element in an array of k2hash keys. 
 
 ## Parameters
@@ -30,6 +32,7 @@ Returns the value of the current element in an array of k2hash keys.
 
 ## Examples
 - Example 1 - Gets a key/value pair using [K2hIterator](k2hiter_class.html)
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -43,7 +46,9 @@ var_dump($k2hiter->current());
 var_dump($k2hiter->key());
 ?>
 ```
+
 The above example will output:
+
 ```
 string(6) "value1"
 string(5) "test1"
@@ -51,6 +56,7 @@ NULL
 string(6) "value2"
 string(5) "test2"
 ```
+
 
 ## See Also
 - [K2hIterator::key](k2hiter_key.html) - Gets key of the current K2hIterator item

--- a/k2hiter_currentja.md
+++ b/k2hiter_currentja.md
@@ -17,9 +17,11 @@ next_string: K2hIterator::key
 配列内の現在の要素を取得する
 
 ## 説明
+
 ```
 public stringfalseK2hIterator::current ( void )
 ```
+
 k2hashのキー配列内の現在の要素の値を取得します。 
 
 ## パラメータ
@@ -30,6 +32,7 @@ k2hashのキー配列内の現在の要素の値を取得します。
 
 ## 例
 - 例 1 - k2hashのキー配列内の現在の要素の値を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -43,7 +46,9 @@ var_dump($k2hiter->current());
 var_dump($k2hiter->key());
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 string(6) "value1"
 string(5) "test1"
@@ -51,6 +56,7 @@ NULL
 string(6) "value2"
 string(5) "test2"
 ```
+
 
 ## 参考
 - [K2hIterator::key](k2hiter_keyja.html) - 配列からキーを取得する

--- a/k2hiter_key.md
+++ b/k2hiter_key.md
@@ -17,9 +17,11 @@ next_string: K2hIterator::next
 Gets key of the current K2hIterator item
 
 ## Description
+
 ```
 public stringfalseK2hIterator::key ( void )
 ```
+
 Gets the key in an array of k2hash keys. 
 
 ## Parameters
@@ -30,6 +32,7 @@ Returns the key.
 
 ## Examples
 - Example 1 - Gets a key using [K2hIterator](k2hiter_class.html)
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -40,10 +43,13 @@ var_dump($k2hiter->key());
 unset($k2hiter);
 ?>
 ```
+
 The above example will output:
+
 ```
 string(5) "test2"
 ```
+
 
 ## See Also
 - [K2hIterator::current](k2hiter_current.html) - Gets value of the current K2hIterator item

--- a/k2hiter_keyja.md
+++ b/k2hiter_keyja.md
@@ -17,9 +17,11 @@ next_string: K2hIterator::next
 配列からキーを取得する
 
 ## 説明
+
 ```
 public stringfalseK2hIterator::key ( void )
 ```
+
 k2hashのキー配列からキーを取得します。 
 
 ## パラメータ
@@ -30,6 +32,7 @@ k2hashのキー配列からキーを取得します。
 
 ## 例
 - 例 1 - k2hashのキー配列からキーを取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -40,10 +43,13 @@ var_dump($k2hiter->key());
 unset($k2hiter);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 string(5) "test2"
 ```
+
 
 ## 参考
 - [K2hIterator::current](k2hiter_currentja.html) - 配列内の現在の要素を取得する

--- a/k2hiter_next.md
+++ b/k2hiter_next.md
@@ -17,9 +17,11 @@ next_string: K2hIterator::rewind
 Advances the internal array pointer of k2hash keys
 
 ## Description
+
 ```
  public void K2hIterator::next ( void )
 ```
+
 Advances the internal array pointer of k2hash keys. 
 
 ## Parameters
@@ -30,13 +32,17 @@ No value is returned.
 
 ## Examples
 - Example 1 - Get a key using [K2hIterator](k2hiter_class.html)
+
 ```
 
 ```
+
 The above example will output:
+
 ```
 string(5) "test2"
 ```
+
 
 ## See Also
 - [K2hIterator::current](k2hiter_current.html) - Gets value of the current K2hIterator item

--- a/k2hiter_nextja.md
+++ b/k2hiter_nextja.md
@@ -17,9 +17,11 @@ next_string: K2hIterator::rewind
 配列のポインタを一つ進める
 
 ## 説明
+
 ```
  public void K2hIterator::next ( void )
 ```
+
 k2hashのキー配列のポインタを一つ進めます。
 
 ## パラメータ
@@ -30,6 +32,7 @@ k2hashのキー配列のポインタを一つ進めます。
 
 ## 例
 - 例 1 - [K2hIterator](k2hiter_classja.html)オブジェクトからキーを取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -41,10 +44,13 @@ var_dump($k2hiter->key());
 unset($k2hiter);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 string(5) "test2"
 ```
+
 
 ## 参考
 - [K2hIterator::current](k2hiter_currentja.html) - 配列内の現在の要素を取得する

--- a/k2hiter_rewind.md
+++ b/k2hiter_rewind.md
@@ -17,9 +17,11 @@ next_string: K2hIterator::valid
 Rewinds the internal array pointer of k2hash keys
 
 ## Description
+
 ```
  public void K2hIterator::rewind ( void )
 ```
+
 Rewinds the internal array pointer of k2hash keys. 
 
 ## Parameters
@@ -30,6 +32,7 @@ No value is returned.
 
 ## Examples
 - Example 1 - Rewinds the internal array pointer of k2hash keys
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -42,10 +45,13 @@ var_dump($k2hiter->key());
 unset($k2hiter);
 ?>
 ```
+
 The above example will output:
+
 ```
 string(5) "test1"
 ```
+
 
 ## See Also
 - [K2hIterator::current](k2hiter_current.html) - Gets value of the current K2hIterator item

--- a/k2hiter_rewindja.md
+++ b/k2hiter_rewindja.md
@@ -17,9 +17,11 @@ next_string: K2hIterator::valid
 配列のポインタを巻き戻します。
 
 ## 説明
+
 ```
  public void K2hIterator::rewind ( void )
 ```
+
 k2hashのキー配列のポインタを巻き戻します。
 
 ## パラメータ
@@ -30,6 +32,7 @@ k2hashのキー配列のポインタを巻き戻します。
 
 ## 例
 - 例 1 - キー配列のポインタを巻き戻します。
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -42,10 +45,13 @@ var_dump($k2hiter->key());
 unset($k2hiter);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 string(5) "test1"
 ```
+
 
 ## 参考
 - [K2hIterator::current](k2hiter_currentja.html) - 配列内の現在の要素を取得する

--- a/k2hiter_valid.md
+++ b/k2hiter_valid.md
@@ -17,9 +17,11 @@ next_string:
 Returns whether the current K2hIterator item is valid
 
 ## Description
+
 ```
  public bool K2hIterator::valid ( void )
 ```
+
 Returns whether the current pointer to an element of k2hash keys is valid. 
 
 ## Parameters
@@ -30,6 +32,7 @@ Returns true if the current pointer to an element of k2hash keys is valid, other
 
 ## Examples
 - Example 1 - Returns whether the current pointer to an element of k2hash keys is valid
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -39,7 +42,10 @@ var_dump($k2hiter->valid());
 unset($k2hiter);
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+

--- a/k2hiter_validja.md
+++ b/k2hiter_validja.md
@@ -17,9 +17,11 @@ next_string:
 ポインタの有効性を調べる
 
 ## 説明
+
 ```
  public bool K2hIterator::valid ( void )
 ```
+
 k2hashのキー配列へのポインタが有効かどうかを調べます。ポインタが配列の要素を指している場合は、有効です。
 
 ## パラメータ
@@ -30,6 +32,7 @@ k2hashのキー配列のポインタが有効な場合にtrue、そうでない�
 
 ## 例
 - 例 1 - k2hashのキー配列のポインタが有効かどうかを調べる
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -39,7 +42,10 @@ var_dump($k2hiter->valid());
 unset($k2hiter);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+

--- a/k2hkq_class.md
+++ b/k2hkq_class.md
@@ -34,11 +34,11 @@ K2hKeyQueue {
 
 ## Method list
 
-- [K2hKeyQueue::__construct](k2hkq_constructja.html) - Creates a K2hKeyQueue instance
-- [K2hKeyQueue::count](k2hkq_countja.html) - Counts elements in the K2hKeyQueue object
-- [K2hKeyQueue::dump](k2hkq_dumpja.html) - Prints the elements in the K2hKeyQueue object
-- [K2hKeyQueue::isEmpty](k2hkq_isEmptyja.html) - Returns whether the K2hKeyQueue is empty
-- [K2hKeyQueue::pop](k2hkq_popja.html) - Removes and returns the removed element from the K2hKeyQueue
-- [K2hKeyQueue::push](k2hkq_pushja.html) - Adds a key/value pair to the K2hKeyQueue
-- [K2hKeyQueue::read](k2hkq_readja.html) - Returns a key/value pair from the K2hKeyQueue
-- [K2hKeyQueue::remove](k2hkq_removeja.html) - Removes a key/value pair from the K2hKeyQueue
+- [K2hKeyQueue::__construct](k2hkq_construct.html) - Creates a K2hKeyQueue instance
+- [K2hKeyQueue::count](k2hkq_count.html) - Counts elements in the K2hKeyQueue object
+- [K2hKeyQueue::dump](k2hkq_dump.html) - Prints the elements in the K2hKeyQueue object
+- [K2hKeyQueue::isEmpty](k2hkq_isempty.html) - Returns whether the K2hKeyQueue is empty
+- [K2hKeyQueue::pop](k2hkq_pop.html) - Removes and returns the removed element from the K2hKeyQueue
+- [K2hKeyQueue::push](k2hkq_push.html) - Adds a key/value pair to the K2hKeyQueue
+- [K2hKeyQueue::read](k2hkq_read.html) - Returns a key/value pair from the K2hKeyQueue
+- [K2hKeyQueue::remove](k2hkq_remove.html) - Removes a key/value pair from the K2hKeyQueue

--- a/k2hkq_class.md
+++ b/k2hkq_class.md
@@ -18,6 +18,7 @@ K2hKeyQueue represents a queue that holds key/value pairs by using [K2HASH](http
 Elements in K2hKeyQueue are ordered in FIFO of LIFO manner.  
 
 ## Class overview
+
 ```
 K2hKeyQueue {
     public count ( void ) : int
@@ -29,6 +30,7 @@ K2hKeyQueue {
     public remove ( int $count [, string $pass ] ) : bool
 }
 ```
+
 
 ## Method list
 

--- a/k2hkq_classja.md
+++ b/k2hkq_classja.md
@@ -19,6 +19,7 @@ K2hKeyQueueクラスは、[K2HASH](https://k2hash.antpick.ax/indexja.html)を利
 データの取り出し方法は、先入先出し（FIFO）、後入れ先出し（LIFO）を指定できます。  
 
 ## Class 概要
+
 ```
 K2hKeyQueue {
     public count ( void ) : int
@@ -30,6 +31,7 @@ K2hKeyQueue {
     public remove ( int $count [, string $pass ] ) : bool
 }
 ```
+
 
 ## メソッド一覧
 

--- a/k2hkq_classja.md
+++ b/k2hkq_classja.md
@@ -35,11 +35,12 @@ K2hKeyQueue {
 
 ## メソッド一覧
 
-- [K2hKeyQueue::__construct](k2hkq_construct.html) - 新しいK2hKeyQueueオブジェクトを作成する
-- [K2hKeyQueue::count](k2hkq_count.html) - キューにある要素の数を取得する
-- [K2hKeyQueue::dump](k2hkq_dump.html) - キューにある要素を表示する
-- [K2hKeyQueue::isEmpty](k2hkq_isEmpty.html) - キューが空かどうかを判定する
-- [K2hKeyQueue::pop](k2hkq_pop.html) - キューから要素（キーと値のセット）を取得する
-- [K2hKeyQueue::push](k2hkq_push.html) - キューに要素（キーと値のセット）を追加する
-- [K2hKeyQueue::read](k2hkq_read.html) - キューの要素（キーと値のセット）を表示する
-- [K2hKeyQueue::remove](k2hkq_remove.html) - キューから要素（キーと値のセット）を削除する
+- [K2hKeyQueue::__construct](k2hkq_constructja.html) - 新しいK2hKeyQueueオブジェクトを作成する
+- [K2hKeyQueue::count](k2hkq_countja.html) - キューにある要素の数を取得する
+- [K2hKeyQueue::dump](k2hkq_dumpja.html) - キューにある要素を表示する
+- [K2hKeyQueue::isEmpty](k2hkq_isemptyja.html) - キューが空かどうかを判定する
+- [K2hKeyQueue::pop](k2hkq_popja.html) - キューから要素（キーと値のセット）を取得する
+- [K2hKeyQueue::push](k2hkq_pushja.html) - キューに要素（キーと値のセット）を追加する
+- [K2hKeyQueue::read](k2hkq_readja.html) - キューの要素（キーと値のセット）を表示する
+- [K2hKeyQueue::remove](k2hkq_removeja.html) - キューから要素（キーと値のセット）を削除する
+

--- a/k2hkq_construct.md
+++ b/k2hkq_construct.md
@@ -17,9 +17,11 @@ next_string: K2hKeyQueue::count
 Creates a K2hKeyQueue instance
 
 ## Description
+
 ```
 public K2hKeyQueue::__construct ( mixed $handle_res [, bool $is_fifo [, string $prefix ]] )
 ```
+
 Creates a [K2hKeyQueue](k2hkq_class.html) instance. 
 
 ## Parameters
@@ -32,6 +34,7 @@ Specifies the prefix of the [K2hKeyQueue](k2hkq_class.html).
 
 ## Examples
 - Example 1 - Creates a [K2hKeyQueue](k2hkq_class.html) instance
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -41,11 +44,14 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 object(K2hKeyQueue)#1 (0) {
 }
 ```
+
 
 ## See Also
 - [K2hash::getKeyQueue](k2h_getkeyqueue.html) - Gets a K2hKeyQueue object

--- a/k2hkq_constructja.md
+++ b/k2hkq_constructja.md
@@ -17,9 +17,11 @@ next_string: K2hKeyQueue::count
 新しいK2hKeyQueueオブジェクトを作成する
 
 ## 説明
+
 ```
 public K2hKeyQueue::__construct ( mixed $handle_res [, bool $is_fifo [, string $prefix ]] )
 ```
+
 新しい[K2hKeyQueue](k2hkq_classja.html)オブジェクトを作成します。 
 
 ## パラメータ
@@ -32,6 +34,7 @@ FIFO(先入先出し)キューならtrue、そうでなければ、false
 
 ## 例
 - 例 1 - [K2hKeyQueue](k2hkq_classja.html)を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -41,11 +44,14 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 object(K2hKeyQueue)#1 (0) {
 }
 ```
+
 
 ## 参考
 - [K2hash::getKeyQueue](k2h_getkeyqueueja.html) - K2hKeyQueueオブジェクトを取得する

--- a/k2hkq_count.md
+++ b/k2hkq_count.md
@@ -17,9 +17,11 @@ next_string: K2hKeyQueue::dump
 Counts elements in the K2hKeyQueue object
 
 ## Description
+
 ```
  public int K2hKeyQueue::count ( void )
 ```
+
 Counts the number of elements in the [K2hKeyQueue](k2hkq_class.html) object. 
 
 ## Parameters
@@ -30,6 +32,7 @@ Returns the number of elements in the [K2hKeyQueue](k2hkq_class.html).
 
 ## Examples
 - Example 1 - Counts elements from [K2hKeyQueue](k2hkq_class.html)
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -43,7 +46,9 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 int(0)
 int(1)
@@ -55,3 +60,4 @@ array(2) {
 }
 int(0)
 ```
+

--- a/k2hkq_countja.md
+++ b/k2hkq_countja.md
@@ -17,9 +17,11 @@ next_string: K2hKeyQueue::dump
 キューにある要素の数を取得する
 
 ## 説明
+
 ```
  public int K2hKeyQueue::count ( void )
 ```
+
 キューにある要素（キーと値のセット）の数を取得します。 
 
 ## パラメータ
@@ -30,6 +32,7 @@ next_string: K2hKeyQueue::dump
 
 ## 例
 - 例 1 - キューからデータを取り出す
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -43,7 +46,9 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 int(0)
 int(1)
@@ -55,3 +60,4 @@ array(2) {
 }
 int(0)
 ```
+

--- a/k2hkq_dump.md
+++ b/k2hkq_dump.md
@@ -17,9 +17,11 @@ next_string: K2hKeyQueue::isEmpty
 Prints the elements in the K2hKeyQueue object
 
 ## Description
+
 ```
  public bool K2hKeyQueue::dump ([ mixed $output ] )
 ```
+
 Gets the elements in the [K2hKeyQueue](k2hkq_class.html) object. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Gets the elements in the [K2hKeyQueue](k2hkq_class.html) object
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -53,7 +56,9 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 MARKER(test_queue_MARKER)= {
@@ -62,3 +67,4 @@ MARKER(test_queue_MARKER)= {
 }
 [0]                    = test_queue_00000000000071EC_0000000061D9D54D_0000000031DD32D2
 ```
+

--- a/k2hkq_dumpja.md
+++ b/k2hkq_dumpja.md
@@ -17,9 +17,11 @@ next_string: K2hKeyQueue::isEmpty
 キューにある要素を表示する
 
 ## 説明
+
 ```
  public bool K2hKeyQueue::dump ([ mixed $output ] )
 ```
+
 キューにある要素（キーと値のセット）を表示します。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ next_string: K2hKeyQueue::isEmpty
 
 ## 例
 - 例 1 - キューを表示する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -53,7 +56,9 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 MARKER(test_queue_MARKER)= {
@@ -62,3 +67,4 @@ MARKER(test_queue_MARKER)= {
 }
 [0]                    = test_queue_00000000000071EC_0000000061D9D54D_0000000031DD32D2
 ```
+

--- a/k2hkq_isempty.md
+++ b/k2hkq_isempty.md
@@ -17,9 +17,11 @@ next_string: K2hKeyQueue::pop
 Returns whether the K2hKeyQueue is empty
 
 ## Description
+
 ```
  public bool K2hKeyQueue::isEmpty ( void )
 ```
+
 Returns where the [K2hKeyQueue](k2hkq_class.html) is empty. 
 
 ## Parameters
@@ -30,6 +32,7 @@ Returns true if the [K2hKeyQueue](k2hkq_class.html) object is empty, otherwise f
 
 ## Examples
 - Example 1 - Get elements from [K2hKeyQueue](k2hkq_class.html)
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -43,7 +46,9 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 int(0)
 int(1)

--- a/k2hkq_isemptyja.md
+++ b/k2hkq_isemptyja.md
@@ -17,9 +17,11 @@ next_string: K2hKeyQueue::pop
 キューが空かどうかを判定する
 
 ## 説明
+
 ```
  public bool K2hKeyQueue::isEmpty ( void )
 ```
+
 キューが空かどうかを判定します。 
 
 ## パラメータ
@@ -30,6 +32,7 @@ next_string: K2hKeyQueue::pop
 
 ## 例
 - 例 1 - キューからデータを取り出す
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -43,7 +46,9 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 int(0)
 int(1)
@@ -55,3 +60,4 @@ array(2) {
 }
 int(0)
 ```
+

--- a/k2hkq_pop.md
+++ b/k2hkq_pop.md
@@ -17,9 +17,11 @@ next_string: K2hKeyQueue::push
 Removes and returns the removed element from the K2hKeyQueue
 
 ## Description
+
 ```
 public arrayfalseK2hKeyQueue::pop ([ string $pass ] )
 ```
+
 Removes and gets the removed element from the [K2hKeyQueue](k2hkq_class.html). 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns a key/value pair.
 
 ## Examples
 - Example 1 - Gets an element from a [K2hKeyQueue](k2hkq_class.html) instance
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -41,7 +44,9 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 array(2) {
   [0]=>
@@ -50,6 +55,7 @@ array(2) {
   string(16) "test_queue_value"
 }
 ```
+
 
 ## See Also
 - [K2hKeyQueue::push](k2hkq_push.html) - Adds a key/value pair to the K2hKeyQueue

--- a/k2hkq_popja.md
+++ b/k2hkq_popja.md
@@ -17,9 +17,11 @@ next_string: K2hKeyQueue::push
 キューから要素（キーと値のセット）を取得する
 
 ## 説明
+
 ```
 public arrayfalseK2hKeyQueue::pop ([ string $pass ] )
 ```
+
 キューから要素（キーと値のセット）を取得します。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ public arrayfalseK2hKeyQueue::pop ([ string $pass ] )
 
 ## 例
 - 例 1 - キューから要素を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -41,7 +44,9 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 array(2) {
   [0]=>
@@ -50,6 +55,7 @@ array(2) {
   string(16) "test_queue_value"
 }
 ```
+
 
 ## 参考
 - [K2hKeyQueue::push](k2hkq_pushja.html) - キューに要素（キーと値のセット）を追加する

--- a/k2hkq_push.md
+++ b/k2hkq_push.md
@@ -17,9 +17,11 @@ next_string: K2hKeyQueue::read
 Adds a key/value pair to the K2hKeyQueue
 
 ## Description
+
 ```
  public bool K2hKeyQueue::push ( string $key , string $value [, string $pass [, int $expire ]] )
 ```
+
 Adds a key/value pair to the [K2hKeyQueue](k2hkq_class.html). 
 
 ## Parameters
@@ -37,6 +39,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Gets an element from a [K2hKeyQueue](k2hkq_class.html) instance
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -47,7 +50,9 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 array(2) {
@@ -57,6 +62,7 @@ array(2) {
   string(16) "test_queue_value"
 }
 ```
+
 
 ## See Also
 - [K2hKeyQueue::pop](k2hkq_pop.html) - Removes and returns the removed element from the K2hKeyQueue

--- a/k2hkq_pushja.md
+++ b/k2hkq_pushja.md
@@ -17,9 +17,11 @@ next_string: K2hKeyQueue::read
 キューに要素（キーと値のセット）を追加する
 
 ## 説明
+
 ```
  public bool K2hKeyQueue::push ( string $key , string $value [, string $pass [, int $expire ]] )
 ```
+
 キューに要素（キーと値のセット）を追加します。 
 
 ## パラメータ
@@ -37,6 +39,7 @@ next_string: K2hKeyQueue::read
 
 ## 例
 - 例 1 - キューから要素を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -47,7 +50,9 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 array(2) {
@@ -57,6 +62,7 @@ array(2) {
   string(16) "test_queue_value"
 }
 ```
+
 
 ## 参考
 - [K2hKeyQueue::pop](k2hkq_popja.html) - キューから要素（キーと値のセット）を取得する

--- a/k2hkq_read.md
+++ b/k2hkq_read.md
@@ -17,9 +17,11 @@ next_string: K2hKeyQueue::remove
 Returns a key/value pair from the K2hKeyQueue
 
 ## Description
+
 ```
 public arrayfalseK2hKeyQueue::read ([ int $pos [, string $pass ]] )
 ```
+
 Returns a key/value pair from the [K2hKeyQueue](k2hkq_class.html). 
 
 ### Note
@@ -36,6 +38,7 @@ Returns a key/value pair.
 
 ## Examples
 - Example 1 - Gets an element from a [K2hKeyQueue](k2hkq_class.html) instance
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,7 +49,9 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 array(2) {
   [0]=>
@@ -55,6 +60,7 @@ array(2) {
   string(16) "test_queue_value"
 }
 ```
+
 
 ## See Also
 - [K2hKeyQueue::pop](k2hkq_pop.html) - Removes and returns the removed element from the K2hKeyQueue

--- a/k2hkq_readja.md
+++ b/k2hkq_readja.md
@@ -17,9 +17,11 @@ next_string: K2hKeyQueue::remove
 キューの要素（キーと値のセット）を表示する
 
 ## 説明
+
 ```
 public arrayfalseK2hKeyQueue::read ([ int $pos [, string $pass ]] )
 ```
+
 キューの要素（キーと値のセット）を表示します。
 
 ### 注意
@@ -36,6 +38,7 @@ public arrayfalseK2hKeyQueue::read ([ int $pos [, string $pass ]] )
 
 ## 例
 - 例 1 - キューから要素を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,7 +49,9 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 array(2) {
   [0]=>
@@ -55,6 +60,7 @@ array(2) {
   string(16) "test_queue_value"
 }
 ```
+
 
 ## 参考
 - [K2hKeyQueue::pop](k2hkq_popja.html) - キューから要素（キーと値のセット）を取得する

--- a/k2hkq_remove.md
+++ b/k2hkq_remove.md
@@ -17,9 +17,11 @@ next_string:
 Removes a key/value pair from the K2hKeyQueue
 
 ## Description
+
 ```
  public bool K2hKeyQueue::remove ( int $count [, string $pass ] )
 ```
+
 Removes a key/value pair from the [K2hKeyQueue](k2hkq_class.html). 
 
 ## Parameters
@@ -33,6 +35,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Gets an element from a [K2hKeyQueue](k2hkq_class.html) instance 
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,12 +49,15 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 int(2)
 bool(true)
 int(1)
 ```
+
 
 ## See Also
 - [K2hKeyQueue::pop](k2hkq_pop.html) - Removes and returns the removed element from the K2hKeyQueue

--- a/k2hkq_removeja.md
+++ b/k2hkq_removeja.md
@@ -17,9 +17,11 @@ next_string:
 キューから要素（キーと値のセット）を削除する
 
 ## 説明
+
 ```
  public bool K2hKeyQueue::remove ( int $count [, string $pass ] )
 ```
+
 キューから要素（キーと値のセット）を削除します。 
 
 ## パラメータ
@@ -33,6 +35,7 @@ next_string:
 
 ## 例
 - 例 1 - キューから要素を削除する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,12 +49,15 @@ unset($k2hkeyqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 int(2)
 bool(true)
 int(1)
 ```
+
 
 ## 参考
 - [K2hKeyQueue::pop](k2hkq_popja.html) - キューから要素（キーと値のセット）を取得する

--- a/k2hpx_add_attr.md
+++ b/k2hpx_add_attr.md
@@ -17,9 +17,11 @@ next_string: k2hpx_add_subkey
 Adds the attribute to the key
 
 ## Description
+
 ```
  bool k2hpx_add_attr ( mixed $handle_res , string $key , string $attrkey , string $attrval )
 ```
+
 Adds the attribute to the key. Attributes represent configurations to keep timestamps of data modification, data encryptions or histories. 
 
 ## Parameters

--- a/k2hpx_add_attr_crypt_pass.md
+++ b/k2hpx_add_attr_crypt_pass.md
@@ -17,9 +17,11 @@ next_string: k2hpx_add_attr_plugin_library
 Adds the password to encrypt values
 
 ## Description
+
 ```
  bool k2hpx_add_attr_crypt_pass ( mixed $handle_res , string $encpass [, bool $is_default_encrypt ] )
 ```
+
 Adds the password to encrypt values. The encrption algorithm is AES256. 
 
 ## Parameters

--- a/k2hpx_add_attr_crypt_passja.md
+++ b/k2hpx_add_attr_crypt_passja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_add_attr_plugin_library
 値を暗号化するパスワード（暗号鍵）を追加する
 
 ## 説明
+
 ```
  bool k2hpx_add_attr_crypt_pass ( mixed $handle_res , string $encpass [, bool $is_default_encrypt ] )
 ```
+
 値を暗号化するパスワードを追加します。パスワードは、AES256共通鍵として使われます。 
 
 ## パラメータ

--- a/k2hpx_add_attr_plugin_library.md
+++ b/k2hpx_add_attr_plugin_library.md
@@ -17,9 +17,11 @@ next_string: k2hpx_add_attr
 Adds the user-defined library to handle attributes
 
 ## Description
+
 ```
 bool k2hpx_add_attr_plugin_library ( mixed $handle_res , string $libfile )
 ```
+
 Adds the user-defined library to handle attributes. k2hash supports for adding user-defined attributes to keys by using this method. 
 
 ## Parameters

--- a/k2hpx_add_attr_plugin_libraryja.md
+++ b/k2hpx_add_attr_plugin_libraryja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_add_attr
 ユーザ定義の動的ライブラリを追加する
 
 ## 説明
+
 ```
 bool k2hpx_add_attr_plugin_library ( mixed $handle_res , string $libfile )
 ```
+
 ユーザ定義の動的ライブラリを追加します。k2hashは、キーに対して任意の属性を付与できます。本メソッドは、ユーザ定義の動的ライブラリを追加し、キーに属性を追加します。 
 
 ## パラメータ

--- a/k2hpx_add_attrja.md
+++ b/k2hpx_add_attrja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_add_subkey
 キーに属性を追加する
 
 ## 説明
+
 ```
  bool k2hpx_add_attr ( mixed $handle_res , string $key , string $attrkey , string $attrval )
 ```
+
 キーに属性を追加します。属性とは、該当キーに対する設定（更新時刻保持の有無、暗号化の有無、履歴情報保持の有無など）です。 
 
 ## パラメータ

--- a/k2hpx_add_subkey.md
+++ b/k2hpx_add_subkey.md
@@ -17,9 +17,11 @@ next_string: k2hpx_add_subkeys
 Associates the key with the other key
 
 ## Description
+
 ```
 bool k2hpx_add_subkey ( mixed $handle_res , string $key , string $subkey )
 ```
+
 Associates the key with the other key. The key that is added to the other key is called 'subkey'. The key that adds the other key to is 'parent key'. A parent key can associates many subkeys. 
 
 ## Parameters

--- a/k2hpx_add_subkeyja.md
+++ b/k2hpx_add_subkeyja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_add_subkeys
 キーを紐づける
 
 ## 説明
+
 ```
 bool k2hpx_add_subkey ( mixed $handle_res , string $key , string $subkey )
 ```
+
 キーに他のキーを紐付けます。紐づけるキーは、紐づけられるキーの「サブキー」と呼びます。 
 
 ## パラメータ

--- a/k2hpx_add_subkeys.md
+++ b/k2hpx_add_subkeys.md
@@ -17,9 +17,11 @@ next_string: k2hpx_bump_debug_level
 Adds the subkeys to the key
 
 ## Description
+
 ```
 bool k2hpx_add_subkeys ( mixed $handle_res , string $key , array $subkeys )
 ```
+
 Associates the keys with the other key. The key that is added to the other key is called 'subkey'. The key that adds the other key to is 'parent key'. A parent key can associates many subkeys.
 
 ## Parameters

--- a/k2hpx_add_subkeysja.md
+++ b/k2hpx_add_subkeysja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_bump_debug_level
 複数のキーを紐づける
 
 ## 説明
+
 ``` 
 k2hpx_add_subkeys ( mixed $handle_res , string $key , array $subkeys ) : bool
 ```
+
 キーに複数のキーを紐付けます。紐づけるキーは、紐づけられるキーの「サブキー」と呼びます。 
 
 ## パラメータ

--- a/k2hpx_bump_debug_level.md
+++ b/k2hpx_bump_debug_level.md
@@ -17,9 +17,11 @@ next_string: k2hpx_clean_common_attr
 Changes the log level
 
 ## Description
+
 ```
 void k2hpx_bump_debug_level ( void )
 ```
+
 Changes the log level by each call. The order is 'error' , 'warning' , 'message' (info), 'dump' (debug), 'silent' (no logging). The log level turns 'error' when calling the function in the 'silent' level. 
 
 ## Parameters
@@ -30,15 +32,19 @@ No value is returned.
 
 ## Examples
 - Example 1 - Changes the log level
+
 ```
 <?php
 var_dump(k2hpx_bump_debug_level());
 ?>
 ```
+
 The above example will output:
+
 ```
 NULL
 ```
+
 
 ## See Also
 - [k2hpx_set_debug_file](k2hpx_set_debug_file.html) - Writes log to the file

--- a/k2hpx_bump_debug_levelja.md
+++ b/k2hpx_bump_debug_levelja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_clean_common_attr
 ログレベルを変更する
 
 ## 説明
+
 ```
 void k2hpx_bump_debug_level ( void )
 ```
+
 ログレベルを変更します。ログレベルは、関数が呼ばれるごとに変わります。順番は、error -> warning -> message(info) -> dump(debug) -> silent(出力しない) の順番です。silentの状態で呼ばれると、errorになります。PHPのログレベルにあたる、emergency, alert, noticeは未定義です。 
 
 ## パラメータ
@@ -30,15 +32,19 @@ void k2hpx_bump_debug_level ( void )
 
 ## 例
 - 例 1 - ログレベルを変更する
+
 ```
 <?php
 var_dump(k2hpx_bump_debug_level());
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 NULL
 ```
+
 
 ## 参考
 - [k2hpx_set_common_attr](k2hpx_set_common_attrja.html) - キーの基本属性を設定する

--- a/k2hpx_clean_common_attr.md
+++ b/k2hpx_clean_common_attr.md
@@ -17,9 +17,11 @@ next_string: k2hpx_close
 Initializes the common attributes
 
 ## Description
+
 ```
 bool k2hpx_clean_common_attr ( mixed $handle_res )
 ```
+
 Initializes the common attributes.
 
 Common attributes are :

--- a/k2hpx_clean_common_attrja.md
+++ b/k2hpx_clean_common_attrja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_close
 キーの基本属性を初期化する
 
 ## 説明
+
 ```
 bool k2hpx_clean_common_attr ( mixed $handle_res )
 ```
+
 キーの基本属性を初期化します。
 
 基本属性は次のとおりです。

--- a/k2hpx_close.md
+++ b/k2hpx_close.md
@@ -17,9 +17,11 @@ next_string: k2hpx_create
 Closes the k2hash file
 
 ## Description
+
 ```
 bool k2hpx_close ( mixed $handle_res [, int $waitms ] )
 ```
+
 Closes the k2hash (`.k2h`) file and saves the data. 
 
 ## Parameters

--- a/k2hpx_closeja.md
+++ b/k2hpx_closeja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_create
 k2hashファイルを閉じる
 
 ## 説明
+
 ```
 bool k2hpx_close ( mixed $handle_res [, int $waitms ] )
 ```
+
 オープンされているk2hashファイルを閉じて、変更内容を保存します。 
 
 ## パラメータ

--- a/k2hpx_create.md
+++ b/k2hpx_create.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_free
 Creates the k2hash file
 
 ## Description
+
 ```
 bool k2hpx_create ( string $filepath [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]] )
 ```
+
 Creates the k2hash (`.k2h`) file. 
 
 ## Parameters

--- a/k2hpx_createja.md
+++ b/k2hpx_createja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_free
 k2hashファイルを作成する
 
 ## 説明
+
 ```
 bool k2hpx_create ( string $filepath [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]] )
 ```
+
 k2hashファイルを作成します。 
 
 ## パラメータ

--- a/k2hpx_da_free.md
+++ b/k2hpx_da_free.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_handle_read
 Frees resources of k2hash direct access handle
 
 ## Description
+
 ```
 bool k2hpx_da_free ( mixed $dahandle_res )
 ```
+
 Releases resources of the [k2hash direct access](https://pages.ghe.corp.yahoo.co.jp/yjcore/k2hash_phpext/en/function.k2hpx-da-free.html) handle. 
 
 ### Note

--- a/k2hpx_da_freeja.md
+++ b/k2hpx_da_freeja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_handle_read
 データアクセスハンドルを解放する
 
 ## 説明
+
 ```
 bool k2hpx_da_free ( mixed $dahandle_res )
 ```
+
 ダイレクトアクセスハンドルを解放します。
 
 ### ヒント

--- a/k2hpx_da_get_handle.md
+++ b/k2hpx_da_get_handle.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_length
 Gets the k2hash direct access file handle
 
 ## Description
+
 ```
 mixed k2hpx_da_get_handle ( mixed $handle_res , string $key , int $mode )
 ```
+
 Gets the k2hash direct access file handle with arbitrary mode: 'K2H_DA_READ' (read-only), 'K2H_DA_RW' (read-write) or 'K2H_DA_WRITE' (write).
 
 ### Note
@@ -38,6 +40,7 @@ Returns the k2hash direct access file handle.
 
 ## Examples
 - Example 1 - Gets the k2hash direct access file handle
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -47,10 +50,13 @@ var_dump(k2hpx_da_free($dahandle));
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 resource(5) of type (k2hdahandle)
 ```
+
 
 ## See Also
 - [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle

--- a/k2hpx_da_get_handle_read.md
+++ b/k2hpx_da_get_handle_read.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_handle_rw
 Reads data
 
 ## Description
+
 ```
 mixed k2hpx_da_get_handle_read ( mixed $handle_res , string $key )
 ```
+
 Gets the k2h direct access file handle with read only mode. 
 
 ### Note
@@ -36,6 +38,7 @@ Returns the k2h direct access file handle with read-only mode.
 
 ## Examples
 - Example 1 - Gets the k2h direct access file handle
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,10 +49,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 resource(5) of type (k2hdahandle)
 ```
+
 
 ## See Also
 - [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle

--- a/k2hpx_da_get_handle_readja.md
+++ b/k2hpx_da_get_handle_readja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_handle_rw
 ダイレクトアクセスハンドル(データ読み出し専用)を取得する
 
 ## 説明
+
 ```
 mixed k2hpx_da_get_handle_read ( mixed $handle_res , string $key )
 ```
+
 ダイレクトアクセスハンドル(データ読み出し専用)を取得します。 
 
 ### ヒント
@@ -36,6 +38,7 @@ k2hash (`.k2h`) ファイルハンドル。 [k2hpx_open](k2hpx_openja.html) 関�
 
 ## 例
 - 例 1 - ダイレクトアクセスハンドル(データ読み出し専用)を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,10 +49,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 resource(5) of type (k2hdahandle)
 ```
+
 
 ## 参考
 - [k2hpx_da_free](k2hpx_da_freeja.html) - データアクセスハンドルを解放する

--- a/k2hpx_da_get_handle_rw.md
+++ b/k2hpx_da_get_handle_rw.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_handle_write
 Gets the k2hash direct access file handle with read-write only mode
 
 ## Description
+
 ```
 mixed k2hpx_da_get_handle_rw ( mixed $handle_res , string $key )
 ```
+
 Gets the k2h direct access file handle with read-write only mode. 
 
 ### Note
@@ -36,6 +38,7 @@ Returns the k2hash direct access file handle with read-write mode.
 
 ## Examples
 - Example 1 - Gets the k2hash direct access file handle
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,10 +49,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 resource(5) of type (k2hdahandle)
 ```
+
 
 ## See Also
 - [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle

--- a/k2hpx_da_get_handle_rwja.md
+++ b/k2hpx_da_get_handle_rwja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_handle_write
 ダイレクトアクセスハンドル(データ編集用)を取得する
 
 ## 説明
+
 ```
 mixed k2hpx_da_get_handle_rw ( mixed $handle_res , string $key )
 ```
+
 ダイレクトアクセスハンドル(データ編集用)を取得します。 
 
 ### ヒント
@@ -36,6 +38,7 @@ k2hash (`.k2h`) ファイルハンドル。 k2hpx_open 関数の戻り値。
 
 ## 例
 - 例 1 - ダイレクトアクセスハンドル(データ編集用)を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,10 +49,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 resource(5) of type (k2hdahandle)
 ```
+
 
 ## 参考
 - [k2hpx_da_free](k2hpx_da_freeja.html) - データアクセスハンドルを解放する

--- a/k2hpx_da_get_handle_write.md
+++ b/k2hpx_da_get_handle_write.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_handle
 Gets the k2hash direct access file handle with write only mode
 
 ## Description
+
 ```
 mixed k2hpx_da_get_handle_write ( mixed $handle_res , string $key )
 ```
+
 Gets the k2hash direct access file handle with write only mode. 
 
 ### Note
@@ -36,6 +38,7 @@ Returns the k2hash direct access file handle with write-only mode.
 
 ## Examples
 - Example 1 - Gets the k2hash direct access file handle
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,10 +49,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 resource(5) of type (k2hdahandle)
 ```
+
 
 ## See Also
 - [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle

--- a/k2hpx_da_get_handle_writeja.md
+++ b/k2hpx_da_get_handle_writeja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_handle
 ダイレクトアクセスハンドル(データ書き込み専用)を取得する
 
 ## 説明
+
 ```
 mixed k2hpx_da_get_handle_write ( mixed $handle_res , string $key )
 ```
+
 ダイレクトアクセスハンドル(データ書き込み専用)を取得します。 
 
 ### ヒント
@@ -36,6 +38,7 @@ k2hash (`.k2h`) ファイルハンドル。 k2hpx_open 関数の戻り値。
 
 ## 例
 - 例 1 - ダイレクトアクセスハンドル(書き込み専用)を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,10 +49,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 resource(5) of type (k2hdahandle)
 ```
+
 
 ## 参考
 - [k2hpx_da_free](k2hpx_da_freeja.html) - データアクセスハンドルを解放する

--- a/k2hpx_da_get_handleja.md
+++ b/k2hpx_da_get_handleja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_length
 ファイル操作方法を指定して、ダイレクトアクセスハンドルを取得する
 
 ## 説明
+
 ```
 mixed k2hpx_da_get_handle ( mixed $handle_res , string $key , int $mode )
 ```
+
 ファイル操作方法を指定して、ダイレクトアクセスハンドルを取得します。  
 ファイル操作方法は、次の通りです。  
 - K2H_DA_READ  
@@ -45,6 +47,7 @@ k2hash (`.k2h`) ファイルハンドル。 k2hpx_open 関数の戻り値。
 
 ## 例
 - 例 1 - ダイレクトアクセスハンドルを取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -54,10 +57,13 @@ var_dump(k2hpx_da_free($dahandle));
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 resource(5) of type (k2hdahandle)
 ```
+
 
 ## 参考
 - [k2hpx_da_free](k2hpx_da_freeja.html) - データアクセスハンドルを解放する

--- a/k2hpx_da_get_length.md
+++ b/k2hpx_da_get_length.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_offset
 Gets the data length
 
 ## Description
+
 ```
 int k2hpx_da_get_length ( mixed $dahandle_res )
 ```
+
 Gets the data length. 
 
 ### Note
@@ -34,6 +36,7 @@ Returns the data length.
 
 ## Examples
 - Example 1 - Gets the data length
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,10 +47,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 int(6)
 ```
+
 
 ## See Also
 - [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle

--- a/k2hpx_da_get_lengthja.md
+++ b/k2hpx_da_get_lengthja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_offset
 データ長を取得する
 
 ## 説明
+
 ```
 int k2hpx_da_get_length ( mixed $dahandle_res )
 ```
+
 値のデータ長を取得します。 
 
 ### ヒント
@@ -34,6 +36,7 @@ k2hash ダイレクトアクセスハンドル（[k2hpx_da_get_handle](k2hpx_da_
 
 ## 例
 - 例 1 - データ長を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,10 +47,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 int(6)
 ```
+
 
 ## 参考
 - [k2hpx_da_free](k2hpx_da_freeja.html) - データアクセスハンドルを解放する

--- a/k2hpx_da_get_offset.md
+++ b/k2hpx_da_get_offset.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_read_offset
 Gets the k2hash direct access file offset with read-write access mode
 
 ## Description
+
 ```
 array k2hpx_da_get_offset ( mixed $dahandle_res )
 ```
+
 Gets the k2hash direct access file offset with read-write access mode. 
 
 ### Note
@@ -34,6 +36,7 @@ Returns the k2hash direct access file offset with read-write access mode.
 
 ## Examples
 - Example 1 - Get the k2hash direct access file offset with read-write access mode
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,7 +47,9 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 array(2) {
   [0]=>
@@ -53,6 +58,7 @@ array(2) {
   int(0)
 }
 ```
+
 
 ## See Also
 - [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle

--- a/k2hpx_da_get_offsetja.md
+++ b/k2hpx_da_get_offsetja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_read_offset
 データを読み書き開始する位置を取得する
 
 ## 説明
+
 ```
 array k2hpx_da_get_offset ( mixed $dahandle_res )
 ```
+
 データを読み書き開始する位置を取得します。 
 
 ### ヒント
@@ -34,6 +36,7 @@ k2hash ダイレクトアクセスハンドル（[k2hpx_da_get_handle](k2hpx_da_
 
 ## 例
 - 例 1 - 直接データを読み書き開始する位置を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,7 +47,9 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 array(2) {
   [0]=>
@@ -53,6 +58,7 @@ array(2) {
   int(0)
 }
 ```
+
 
 ## 参考
 - [k2hpx_da_free](k2hpx_da_freeja.html) - データアクセスハンドルを解放する

--- a/k2hpx_da_get_read_offset.md
+++ b/k2hpx_da_get_read_offset.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_value_to_file
 Gets the k2hash direct access file offset with read access mode
 
 ## Description
+
 ```
 int k2hpx_da_get_read_offset ( mixed $dahandle_res )
 ```
+
 Gets the k2hash direct access file offset with read access mode. 
 
 ### Note
@@ -34,6 +36,7 @@ Returns the k2hash direct access file offset with read access mode.
 
 ## Examples
 - Example 1 - Get the k2hash direct access file offset with read access mode
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,10 +47,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 int(0)
 ```
+
 
 ## See Also
 - [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle

--- a/k2hpx_da_get_read_offsetja.md
+++ b/k2hpx_da_get_read_offsetja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_value_to_file
 データを読みとり開始する位置を取得する
 
 ## 説明
+
 ```
 int k2hpx_da_get_read_offset ( mixed $dahandle_res )
 ```
+
 データを読みとり開始する位置を取得します。 
 
 ### ヒント
@@ -34,6 +36,7 @@ k2hash ダイレクトアクセスハンドル（[k2hpx_da_get_handle](k2hpx_da_
 
 ## 例
 - 例 1 - データを読み書き開始する位置を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,10 +47,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 int(0)
 ```
+
 
 ## 参考
 - [k2hpx_da_free](k2hpx_da_freeja.html) - データアクセスハンドルを解放する

--- a/k2hpx_da_get_value.md
+++ b/k2hpx_da_get_value.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_write_offset
 Reads value using the offset
 
 ## Description
+
 ```
 string k2hpx_da_get_value ( mixed $dahandle_res [, int $offset ] )
 ```
+
 Reads value using the offset. 
 
 ### Note
@@ -36,6 +38,7 @@ Returns the data to be read.
 
 ## Examples
 - Example 1 - Reads value using the offset
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,10 +49,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 string(3) "lue"
 ```
+
 
 ## See Also
 - [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle

--- a/k2hpx_da_get_value_to_file.md
+++ b/k2hpx_da_get_value_to_file.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_value
 Reads value using the offset and write it to the file
 
 ## Description
+
 ```
 bool k2hpx_da_get_value_to_file ( mixed $dahandle_res , string $filepath [, int $length [, int $offset ]] )
 ```
+
 Reads value using the offset and write it to the file. 
 
 ### Note
@@ -40,6 +42,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Reads data and write it to the file
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -50,10 +53,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+
 
 ## See Also
 - [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle

--- a/k2hpx_da_get_value_to_fileja.md
+++ b/k2hpx_da_get_value_to_fileja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_value
 読み取った値をファイルに書き出す
 
 ## 説明
+
 ```
 bool k2hpx_da_get_value_to_file ( mixed $dahandle_res , string $filepath [, int $length [, int $offset ]] )
 ```
+
 読み取ったデータをファイルに書き出します。
 
 ### ヒント
@@ -40,6 +42,7 @@ k2hash ダイレクトアクセスハンドル（[k2hpx_da_get_handle](k2hpx_da_
 
 ## 例
 - 例 1 - 読み取ったデータをファイルに保存する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -50,10 +53,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+
 
 ## 参考
 - [k2hpx_da_free](k2hpx_da_freeja.html) - データアクセスハンドルを解放する

--- a/k2hpx_da_get_valueja.md
+++ b/k2hpx_da_get_valueja.md
@@ -58,18 +58,20 @@ string(3) "lue"
 
 
 ## 参考
-- [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle
-- [k2hpx_da_get_handle_read](k2hpx_da_get_handle_read.html) - Reads data
-- [k2hpx_da_get_handle_rw](k2hpx_da_get_handle_rw.html) - Gets the k2h direct access file handle with read-write only mode
-- [k2hpx_da_get_handle_write](k2hpx_da_get_handle_write.html) - Gets the k2h direct access file handle with write only mode
-- [k2hpx_da_get_handle](k2hpx_da_get_handle.html) - Gets the k2h direct access file handle
-- [k2hpx_da_get_length](k2hpx_da_get_length.html) - Gets the data length
-- [k2hpx_da_get_offset](k2hpx_da_get_offset.html) - Gets the k2h direct access file offset with read-write access mode
-- [k2hpx_da_get_read_offset](k2hpx_da_get_read_offset.html) - Gets the k2h direct access file offset with read access mode
-- [k2hpx_da_get_value_to_file](k2hpx_da_get_value_to_file.html) - Reads value using the offset and write it to the file
-- [k2hpx_da_get_write_offset](k2hpx_da_get_write_offset.html) - Gets the k2h direct access file offset with write access mode
-- [k2hpx_da_set_offset](k2hpx_da_set_offset.html) - Sets the offset to modify the data
-- [k2hpx_da_set_read_offset](k2hpx_da_set_read_offset.html) - Sets the offset to read the data
-- [k2hpx_da_set_value_from_file](k2hpx_da_set_value_from_file.html) - Sets value using the offset reading data from the file with length
-- [k2hpx_da_set_value](k2hpx_da_set_value.html) - Sets value
-- [k2hpx_da_set_write_offset](k2hpx_da_set_write_offset.html) - Sets value using the offset
+- [k2hpx_da_free](k2hpx_da_freeja.html) - データアクセスハンドルを解放する
+- [k2hpx_da_get_handle_read](k2hpx_da_get_handle_readja.html) - ダイレクトアクセスハンドル(データ読み出し専用)を取得する
+- [k2hpx_da_get_handle_rw](k2hpx_da_get_handle_rwja.html) - ダイレクトアクセスハンドル(データ編集用)を取得する
+- [k2hpx_da_get_handle_write](k2hpx_da_get_handle_writeja.html) - ダイレクトアクセスハンドル(データ書き込み専用)を取得する
+- [k2hpx_da_get_handle](k2hpx_da_get_handleja.html) - ファイル操作方法を指定して、ダイレクトアクセスハンドルを取得する
+- [k2hpx_da_get_length](k2hpx_da_get_lengthja.html) - データ長を取得する
+- [k2hpx_da_get_offset](k2hpx_da_get_offsetja.html) - データを読み書き開始する位置を取得する
+- [k2hpx_da_get_read_offset](k2hpx_da_get_read_offsetja.html) - データを読みとり開始する位置を取得する
+- [k2hpx_da_get_value_to_file](k2hpx_da_get_value_to_fileja.html) - 読み取った値をファイルに書き出す
+- [k2hpx_da_get_value](k2hpx_da_get_valueja.html) - データを読み取る
+- [k2hpx_da_get_write_offset](k2hpx_da_get_write_offsetja.html) - データの書き込み開始する位置を取得する
+- [k2hpx_da_set_offset](k2hpx_da_set_offsetja.html) - データを読み込むまたは書き込む位置を指定する
+- [k2hpx_da_set_read_offset](k2hpx_da_set_read_offsetja.html) - データを読み込む位置を指定する
+- [k2hpx_da_set_value_from_file](k2hpx_da_set_value_from_fileja.html) - ファイルから書き込むデータを読み込み、直接データを書きこむ位置を指定し、書き込む
+- [k2hpx_da_set_value](k2hpx_da_set_valueja.html) - データを書きこむ位置を指定し、書き込む
+- [k2hpx_da_set_write_offset](k2hpx_da_set_write_offsetja.html) - データを書き込む位置を指定する
+

--- a/k2hpx_da_get_valueja.md
+++ b/k2hpx_da_get_valueja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_get_write_offset
 データを読み取る
 
 ## 説明
+
 ```
 string k2hpx_da_get_value ( mixed $dahandle_res [, int $offset ] )
 ```
+
 データを読み取ります。 
 
 ### ヒント
@@ -36,6 +38,7 @@ k2hash ダイレクトアクセスハンドル（[k2hpx_da_get_handle](k2hpx_da_
 
 ## 例
 - 例 1 - データを読みとる
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,10 +49,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 string(3) "lue"
 ```
+
 
 ## 参考
 - [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle

--- a/k2hpx_da_get_write_offset.md
+++ b/k2hpx_da_get_write_offset.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_set_offset
 Gets the k2hash direct access file offset with write access mode
 
 ## Description
+
 ```
 int k2hpx_da_get_write_offset ( mixed $dahandle_res )
 ```
+
 Gets the k2hash direct access file offset with write access mode. 
 
 ### Note
@@ -34,6 +36,7 @@ Returns the k2hash direct access file offset with write access mode.
 
 ## Examples
 - Example 1 - Returns the k2hash direct access file offset with write access mode
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,10 +47,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 int(0)
 ```
+
 
 ## See Also
 - [k2hpx_da_get_handle_read](k2hpx_da_get_handle_read.html) - Reads data

--- a/k2hpx_da_get_write_offsetja.md
+++ b/k2hpx_da_get_write_offsetja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_set_offset
 データの書き込み開始する位置を取得する
 
 ## 説明
+
 ```
 int k2hpx_da_get_write_offset ( mixed $dahandle_res )
 ```
+
 データの書き込み開始する位置を取得します。 
 
 ### ヒント
@@ -34,6 +36,7 @@ k2hash ダイレクトアクセスハンドル（[k2hpx_da_get_handle](k2hpx_da_
 
 ## 例
 - 例 1 - データを書き込み開始する位置を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,10 +47,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 int(0)
 ```
+
 
 ## 参考
 - [k2hpx_da_free](k2hpx_da_freeja.html) - データアクセスハンドルを解放する

--- a/k2hpx_da_set_offset.md
+++ b/k2hpx_da_set_offset.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_set_read_offset
 Sets the offset to modify the data
 
 ## Description
+
 ```
 int 2hpx_da_set_offset ( mixed $dahandle_res , array $offsets )
 ```
+
 
 ### Note
 The [k2hash direct access](https://pages.ghe.corp.yahoo.co.jp/yjcore/k2hash_phpext/en/function.k2hpx-da-free.html) handle is a handler to provide quick access to the specific part of large data using offset. 
@@ -35,6 +37,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Sets the offset to modify the data
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -48,7 +51,9 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 array(2) {
   [0]=>
@@ -64,6 +69,7 @@ array(2) {
   int(20)
 }
 ```
+
 
 ## See Also
 - [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle

--- a/k2hpx_da_set_offsetja.md
+++ b/k2hpx_da_set_offsetja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_set_read_offset
 データを読み込むまたは書き込む位置を指定する
 
 ## 説明
+
 ```
 int k2hpx_da_set_offset ( mixed $dahandle_res , array $offsets )
 ```
+
 データを読み込むまたは書き込む位置を指定します。
 
 ### ヒント
@@ -36,6 +38,7 @@ k2hash ダイレクトアクセスハンドル（[k2hpx_da_get_handle](k2hpx_da_
 
 ## 例
 - 例 1 - データを読み書き開始する位置を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -49,7 +52,9 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 array(2) {
   [0]=>
@@ -65,6 +70,7 @@ array(2) {
   int(20)
 }
 ```
+
 
 ## 参考
 - [k2hpx_da_free](k2hpx_da_freeja.html) - データアクセスハンドルを解放する

--- a/k2hpx_da_set_read_offset.md
+++ b/k2hpx_da_set_read_offset.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_set_value_from_file
 Sets the offset to read the data
 
 ## Description
+
 ```
 int k2hpx_da_set_read_offset ( mixed $dahandle_res , int $offset )
 ```
+
 Sets the offset to read the data. 
 
 ### Note
@@ -36,6 +38,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Sets the offset to read the data
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -48,7 +51,9 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 array(2) {
   [0]=>
@@ -64,6 +69,7 @@ array(2) {
   int(0)
 }
 ```
+
 
 ## See Also
 - [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle

--- a/k2hpx_da_set_read_offsetja.md
+++ b/k2hpx_da_set_read_offsetja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_set_value_from_file
 データを読み込む位置を指定する
 
 ## 説明
+
 ```
 int k2hpx_da_set_read_offset ( mixed $dahandle_res , int $offset )
 ```
+
 データを読み込む位置を指定します。 
 
 ### ヒント
@@ -36,6 +38,7 @@ k2hash ダイレクトアクセスハンドル（[k2hpx_da_get_handle](k2hpx_da_
 
 ## 例
 - 例 1 - データを読み込む位置を指定する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -48,7 +51,9 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 array(2) {
   [0]=>
@@ -64,6 +69,7 @@ array(2) {
   int(0)
 }
 ```
+
 
 ## 参考
 - [k2hpx_da_free](k2hpx_da_freeja.html) - データアクセスハンドルを解放する

--- a/k2hpx_da_set_value.md
+++ b/k2hpx_da_set_value.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_set_write_offset
 Sets value
 
 ## Description
+
 ```
 bool k2hpx_da_set_value ( mixed $dahandle_res , string $value [, int $offset ] )
 ```
+
 Sets value using the offset. 
 
 ### Note
@@ -38,6 +40,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Sets value using the offset
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -49,11 +52,14 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 string(5) "value"
 ```
+
 
 ## See Also
 - [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle

--- a/k2hpx_da_set_value_from_file.md
+++ b/k2hpx_da_set_value_from_file.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_set_value
 Sets value using the offset reading data from the file with length
 
 ## Description
+
 ```
 bool k2hpx_da_set_value_from_file ( mixed $dahandle_res , string $filepath [, int $length [, int $offset ]] )
 ```
+
 Sets value using the offset reading data from the file with length. 
 
 ### Note
@@ -40,6 +42,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Sets value using the offset reading data from the file with length
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -51,10 +54,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+
 
 ## See Also
 - [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle

--- a/k2hpx_da_set_value_from_fileja.md
+++ b/k2hpx_da_set_value_from_fileja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_set_value
 ファイルから書き込むデータを読み込み、直接データを書きこむ位置を指定し、書き込む
 
 ## 説明
+
 ```
 bool k2hpx_da_set_value_from_file ( mixed $dahandle_res , string $filepath [, int $length [, int $offset ]] )
 ```
+
 ファイルから書き込むデータを読み込み、直接データを書きこむ位置を指定し、書き込みます。 
 
 ### ヒント
@@ -40,6 +42,7 @@ k2hash ダイレクトアクセスハンドル（[k2hpx_da_get_handle](k2hpx_da_
 
 ## 例
 - 例 1 - ファイルから書き込むデータを読み込み、直接データを書きこむ位置を指定し、書き込む
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -51,10 +54,13 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+
 
 ## 参考
 - [k2hpx_da_free](k2hpx_da_freeja.html) - データアクセスハンドルを解放する

--- a/k2hpx_da_set_valueja.md
+++ b/k2hpx_da_set_valueja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_da_set_write_offset
 データを書きこむ位置を指定し、書き込む
 
 ## 説明
+
 ```
 bool k2hpx_da_set_value ( mixed $dahandle_res , string $value [, int $offset ] )
 ```
+
 データを書きこむ位置を指定し、書き込みます。 
 
 ### ヒント
@@ -38,6 +40,7 @@ k2hash ダイレクトアクセスハンドル（[k2hpx_da_get_handle](k2hpx_da_
 
 ## 例
 - 例 1 - 書き込み位置を指定してデータをセットする
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -49,11 +52,14 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 string(5) "value"
 ```
+
 
 ## 参考
 - [k2hpx_da_free](k2hpx_da_freeja.html) - データアクセスハンドルを解放する

--- a/k2hpx_da_set_write_offset.md
+++ b/k2hpx_da_set_write_offset.md
@@ -17,9 +17,11 @@ next_string: k2hpx_disable_transaction
 Sets value using the offset
 
 ## Description
+
 ```
 int k2hpx_da_set_write_offset ( mixed $dahandle_res , int $offset )
 ```
+
 Sets value using the offset. 
 
 ### Note
@@ -36,6 +38,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Sets value using the offset
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -48,7 +51,9 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 array(2) {
   [0]=>
@@ -64,6 +69,7 @@ array(2) {
   int(5)
 }
 ```
+
 
 ## See Also
 - [k2hpx_da_free](k2hpx_da_free.html) - Frees resources of k2hash direct access handle

--- a/k2hpx_da_set_write_offsetja.md
+++ b/k2hpx_da_set_write_offsetja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_disable_transaction
 データを書き込む位置を指定する
 
 ## 説明
+
 ```
 int k2hpx_da_set_write_offset ( mixed $dahandle_res , int $offset )
 ```
+
 データを書き込む位置を指定します。 
 
 ### ヒント
@@ -36,6 +38,7 @@ k2hash ダイレクトアクセスハンドル（[k2hpx_da_get_handle](k2hpx_da_
 
 ## 例
 - 例 1 - データを読み込む位置を指定する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -48,7 +51,9 @@ k2hpx_da_free($dahandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 array(2) {
   [0]=>
@@ -64,6 +69,7 @@ array(2) {
   int(5)
 }
 ```
+
 
 ## 参考
 - [k2hpx_da_free](k2hpx_da_freeja.html) - データアクセスハンドルを解放する

--- a/k2hpx_disable_transaction.md
+++ b/k2hpx_disable_transaction.md
@@ -17,9 +17,11 @@ next_string: k2hpx_dump_elementtable
 Stops a transaction
 
 ## Description
+
 ```
 bool k2hpx_disable_transaction ( mixed $handle_res )
 ```
+
 Stops a transaction. 
 
 ## Parameters

--- a/k2hpx_disable_transactionja.md
+++ b/k2hpx_disable_transactionja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_dump_elementtable
 トランザクションを停止する
 
 ## 説明
+
 ```
 bool k2hpx_disable_transaction ( mixed $handle_res )
 ```
+
 トランザクションを停止します
 
 ## パラメータ

--- a/k2hpx_dump_elementtable.md
+++ b/k2hpx_dump_elementtable.md
@@ -17,9 +17,11 @@ next_string: k2hpx_dump_full_keytable
 Prints elements of the k2hash's hash table elements
 
 ## Description
+
 ```
 bool k2hpx_dump_elementtable ( mixed $handle_res [, mixed $output ] )
 ```
+
 Prints elements of the k2hash hashtable elements including headers, hash tables and sub-hash tables. 
 
 ## Parameters

--- a/k2hpx_dump_elementtableja.md
+++ b/k2hpx_dump_elementtableja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_dump_full_keytable
 k2hashのハッシュテーブル内部の要素などを表示する
 
 ## 説明
+
 ```
 bool k2hpx_dump_elementtable ( mixed $handle_res [, mixed $output ] )
 ```
+
 k2hashのハッシュテーブル内部の要素などを表示します。k2hashのヘッダ、ハッシュテーブル、サブハッシュテーブルなども含まれます。 
 
 ## パラメータ

--- a/k2hpx_dump_full.md
+++ b/k2hpx_dump_full.md
@@ -17,9 +17,11 @@ next_string: k2hpx_dump_head
 Prints the k2hash's hash tables in details
 
 ## Description
+
 ```
 bool k2hpx_dump_full ( mixed $handle_res [, mixed $output ] )
 ```
+
 Prints the k2hash's hash tables in details including headers, hash tables and sub-hash tables. 
 
 ## Parameters

--- a/k2hpx_dump_full_keytable.md
+++ b/k2hpx_dump_full_keytable.md
@@ -17,9 +17,11 @@ next_string: k2hpx_dump_full
 Prints details of the k2hash's hash tables
 
 ## Description
+
 ```
 bool k2hpx_dump_full_keytable ( mixed $handle_res [, mixed $output ] )
 ```
+
  Prints details of the k2hash's hash tables including headers, hash tables and sub-hash tables. 
 
 ## Parameters

--- a/k2hpx_dump_full_keytableja.md
+++ b/k2hpx_dump_full_keytableja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_dump_full
 k2hashのハッシュテーブルなどを表示する
 
 ## 説明
+
 ```
 bool k2hpx_dump_full_keytable ( mixed $handle_res [, mixed $output ] )
 ```
+
 k2hashのハッシュテーブルなどを表示します。k2hashのヘッダ、ハッシュテーブル、サブハッシュテーブルなども含まれます。 
 
 ## パラメータ

--- a/k2hpx_dump_fullja.md
+++ b/k2hpx_dump_fullja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_dump_head
 k2hashのハッシュテーブル内部のデータなどを表示する
 
 ## 説明
+
 ```
 bool k2hpx_dump_full ( mixed $handle_res [, mixed $output ] )
 ```
+
 k2hashのハッシュテーブル内部のデータなどを表示します。k2hashのヘッダ、ハッシュテーブル、サブハッシュテーブル、テーブル内部の要素なども含まれます。
 
 ## パラメータ

--- a/k2hpx_dump_head.md
+++ b/k2hpx_dump_head.md
@@ -17,9 +17,11 @@ next_string: k2hpx_dump_keytable
 Prints the k2hash's headers
 
 ## Description
+
 ```
 bool k2hpx_dump_head ( mixed $handle_res [, mixed $output ] )
 ```
+
 Prints the k2hash's headers. 
 
 ## Parameters

--- a/k2hpx_dump_headja.md
+++ b/k2hpx_dump_headja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_dump_keytable
 k2hashのヘッダを表示する
 
 ## 説明
+
 ```
 bool k2hpx_dump_head ( mixed $handle_res [, mixed $output ] )
 ```
+
 k2hashのヘッダを表示します。 
 
 ## パラメータ

--- a/k2hpx_dump_keytable.md
+++ b/k2hpx_dump_keytable.md
@@ -17,9 +17,11 @@ next_string: k2hpx_enable_transaction
 Prints the k2hash's hash tables
 
 ## Description
+
 ```
 bool k2hpx_dump_keytable ( mixed $handle_res [, mixed $output ] )
 ```
+
 Prints the k2hash's hash tables including k2hash headers. 
 
 ## Parameters

--- a/k2hpx_dump_keytableja.md
+++ b/k2hpx_dump_keytableja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_enable_transaction
 k2hashのハッシュテーブルを表示する
 
 ## 説明
+
 ```
 bool k2hpx_dump_keytable ( mixed $handle_res [, mixed $output ] )
 ```
+
 k2hashのハッシュテーブルなどを表示します。k2hashのヘッダ、ハッシュテーブルなども含まれます。 
 
 ## パラメータ

--- a/k2hpx_enable_transaction.md
+++ b/k2hpx_enable_transaction.md
@@ -17,9 +17,11 @@ next_string: k2hpx_find_first
 Starts a transaction
 
 ## Description
+
 ```
 bool k2hpx_enable_transaction ( mixed $handle_res [, stringnull $transfile [, stringnull $prefix [, stringnull $param [, int $expire ]]]] )
 ```
+
 Starts a transaction. 
 
 ## Parameters

--- a/k2hpx_enable_transactionja.md
+++ b/k2hpx_enable_transactionja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_find_first
 トランザクションを開始する
 
 ## 説明
+
 ```
 bool k2hpx_enable_transaction ( mixed $handle_res [, stringnull $transfile [, stringnull $prefix [, stringnull $param [, int $expire ]]]] )
 ```
+
 トランザクションを開始します。 
 
 ## パラメータ

--- a/k2hpx_find_first.md
+++ b/k2hpx_find_first.md
@@ -17,9 +17,11 @@ next_string: k2hpx_find_free
 Gets the k2hash file handle to search for the key
 
 ## Description
+
 ```
 mixed k2hpx_find_first ( mixed $handle_res [, stringnull $key ] )
 ```
+
 Gets the k2hash file handle to searchf for the key. 
 
 ## Parameters
@@ -33,6 +35,7 @@ Returns the k2hash file handle to search for the key.
 
 ## Examples
 - Example 1 - Gets the k2hash file handle to search for the key
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -43,10 +46,13 @@ k2hpx_find_free($findhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 resource(5) of type (k2hfindhandle)
 ```
+
 
 ## See Also
 - [k2hpx_find_free](k2hpx_find_free.html) - Releases resources of the k2h file handle to search for keys

--- a/k2hpx_find_firstja.md
+++ b/k2hpx_find_firstja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_find_free
 キー探索用ハンドルを取得する
 
 ## 説明
+
 ```
 mixed k2hpx_find_first ( mixed $handle_res [, stringnull $key ] )
 ```
+
 キー探索用ハンドルを取得します。 
 
 ## パラメータ
@@ -33,6 +35,7 @@ k2hash (`.k2h`) ファイルハンドル。 [k2hpx_open](k2hpx_openja.html) 関�
 
 ## 例
 - 例 1 - キー探索用ファイルハンドルを取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -43,10 +46,13 @@ k2hpx_find_free($findhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 resource(5) of type (k2hfindhandle)
 ```
+
 
 ## 参考
 - [k2hpx_find_free](k2hpx_find_freeja.html) - キー探索用ハンドルを解放する

--- a/k2hpx_find_free.md
+++ b/k2hpx_find_free.md
@@ -17,9 +17,11 @@ next_string: k2hpx_find_get_key
 Releases resources of the k2hash file handle to search for keys
 
 ## Description
+
 ```
 bool k2hpx_find_free ( mixed $findhandle_res )
 ```
+
 Releases resources of the k2hash file handle to search for keys
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Releases resources of the k2hash file handle to search for keys
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -41,10 +44,13 @@ k2hpx_find_free($findhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 resource(5) of type (k2hfindhandle)
 ```
+
 
 ## See Also
 - [k2hpx_find_first](k2hpx_find_first.html) - Gets the k2h file handle to search for the key

--- a/k2hpx_find_freeja.md
+++ b/k2hpx_find_freeja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_find_get_key
 キー探索用ハンドルを解放する
 
 ## 説明
+
 ```
 bool k2hpx_find_free ( mixed $findhandle_res )
 ```
+
 キー探索用ハンドルを解放します。
 
 ## パラメータ
@@ -31,6 +33,7 @@ k2hash キー探索用ハンドル（ [k2hpx_find_first](k2hpx_find_firstja.html
 
 ## 例
 - 例 1 - キー探索用ファイルハンドルを解放する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -41,10 +44,13 @@ k2hpx_find_free($findhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 resource(5) of type (k2hfindhandle)
 ```
+
 
 ## 参考
 - [k2hpx_find_first](k2hpx_find_firstja.html) - キー探索用ハンドルを取得する

--- a/k2hpx_find_get_key.md
+++ b/k2hpx_find_get_key.md
@@ -17,9 +17,11 @@ next_string: k2hpx_find_get_subkeys
 Gets keys using the k2hash file handle to search for keys
 
 ## Description
+
 ```
 string k2hpx_find_get_key ( mixed $findhandle_res )
 ```
+
 Gets keys using the k2hash file handle to search for keys. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns keys to be searched for.
 
 ## Examples
 - Example 1 - Gets keys using the k2hash file handle to search for keys
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -42,11 +45,14 @@ k2hpx_find_free($findhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 resource(5) of type (k2hfindhandle)
 string(5) "test1"
 ```
+
 
 ## See Also
 - [k2hpx_find_first](k2hpx_find_first.html) - Gets the k2h file handle to search for the key

--- a/k2hpx_find_get_keyja.md
+++ b/k2hpx_find_get_keyja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_find_get_subkeys
 キーを探索する
 
 ## 説明
+
 ```
 string k2hpx_find_get_key ( mixed $findhandle_res )
 ```
+
 キーを探索します。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ k2hash キー探索用ハンドル（ [k2hpx_find_first](k2hpx_find_firstja.html
 
 ## 例
 - 例 1 - キー探索用ファイルハンドルを取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -42,11 +45,14 @@ k2hpx_find_free($findhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 resource(5) of type (k2hfindhandle)
 string(5) "test1"
 ```
+
 
 ## 参考
 - [k2hpx_find_first](k2hpx_find_firstja.html) - キー探索用ハンドルを取得する

--- a/k2hpx_find_get_subkeys.md
+++ b/k2hpx_find_get_subkeys.md
@@ -17,9 +17,11 @@ next_string: k2hpx_find_get_value
 Gets keys using the k2hash file handle to search for keys with linked with each key
 
 ## Description
+
 ```
 array k2hpx_find_get_subkeys ( mixed $findhandle_res )
 ```
+
 Gets keys using the k2hash file handle to search for keys with linked with each key. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns an array of keys that is lnked with each keys.
 
 ## Examples
 - Example 1 - Gets keys using the k2hash file handle to search for keys with linked with each key
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,7 +47,9 @@ k2hpx_find_free($findhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 resource(5) of type (k2hfindhandle)
 array(1) {
@@ -52,6 +57,7 @@ array(1) {
   string(7) "subkey1"
 }
 ```
+
 
 ## See Also
 - [k2hpx_find_first](k2hpx_find_first.html) - Gets the k2h file handle to search for the key

--- a/k2hpx_find_get_subkeysja.md
+++ b/k2hpx_find_get_subkeysja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_find_get_value
 キーに紐づけられたキーを探索する
 
 ## 説明
+
 ```
 array k2hpx_find_get_subkeys ( mixed $findhandle_res )
 ```
+
 キーに紐づけられたキー（サブキー）を探索します。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ k2hash キー探索用ハンドル（ [k2hpx_find_first](k2hpx_find_firstja.html
 
 ## 例
 - 例 1 - 探索結果のキーに紐づけられたキー（サブキー） を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,7 +47,9 @@ k2hpx_find_free($findhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 resource(5) of type (k2hfindhandle)
 array(1) {
@@ -52,6 +57,7 @@ array(1) {
   string(7) "subkey1"
 }
 ```
+
 
 ## 参考
 - [k2hpx_find_first](k2hpx_find_firstja.html) - キー探索用ハンドルを取得する

--- a/k2hpx_find_get_value.md
+++ b/k2hpx_find_get_value.md
@@ -17,9 +17,11 @@ next_string: k2hpx_find_next
 Gets value using the k2hash file handle to search for keys
 
 ## Description
+
 ```
 string k2hpx_find_get_value ( mixed $findhandle_res )
 ```
+
 Gets value using the k2hash file handle to search for keys. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns value of each key.
 
 ## Examples
 - Example 1 - Gets value using the k2hash file handle to search for keys
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,11 +47,14 @@ k2hpx_find_free($findhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 resource(5) of type (k2hfindhandle)
 string(6) "value1"
 ```
+
 
 ## See Also
 - [k2hpx_find_first](k2hpx_find_first.html) - Gets the k2h file handle to search for the key

--- a/k2hpx_find_get_valueja.md
+++ b/k2hpx_find_get_valueja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_find_next
 キーを探索して値を取得する
 
 ## 説明
+
 ```
 string k2hpx_find_get_value ( mixed $findhandle_res )
 ```
+
 キーを探索して値を取得します。
 
 ## パラメータ
@@ -31,6 +33,7 @@ k2hash キー探索用ハンドル（ [k2hpx_find_first](k2hpx_find_firstja.html
 
 ## 例
 - 例 1 - 探索結果のキーに紐づけられた値を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,11 +47,14 @@ k2hpx_find_free($findhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 resource(5) of type (k2hfindhandle)
 string(6) "value1"
 ```
+
 
 ## 参考
 - [k2hpx_find_first](k2hpx_find_firstja.html) - キー探索用ハンドルを取得する

--- a/k2hpx_find_next.md
+++ b/k2hpx_find_next.md
@@ -17,9 +17,11 @@ next_string: k2hpx_get_attr_value
 Advances the internal pointer of the k2hash file handle to search for keys
 
 ## Description
+
 ```
 mixed k2hpx_find_next ( mixed $findhandle_res )
 ```
+
 Advances the internal pointer of the k2hash file handle to search for keys. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns the pointer to the next key.
 
 ## Examples
 - Example 1 - Gets the key and the value using the k2hash file handle that [k2hpx_find_first](k2hpx_find_first.html) returns
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -45,13 +48,16 @@ k2hpx_find_free($findhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 resource(5) of type (k2hfindhandle)
 string(5) "test1"
 resource(6) of type (k2hfindhandle)
 string(5) "test2"
 ```
+
 
 ## See Also
 - [k2hpx_find_first](k2hpx_find_first.html) - Gets the k2h file handle to search for the key

--- a/k2hpx_find_nextja.md
+++ b/k2hpx_find_nextja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_get_attr_value
 キー探索用ハンドルを次のキーに移動する
 
 ## 説明
+
 ```
 mixed k2hpx_find_next ( mixed $findhandle_res )
 ```
+
 キー探索用ハンドルを次のキーに移動します。
 
 ## パラメータ
@@ -31,6 +33,7 @@ k2hash キー探索用ハンドル（ [k2hpx_find_first](k2hpx_find_firstja.html
 
 ## 例
 - 例 1 - キー探索用ファイルハンドルを取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -45,13 +48,16 @@ k2hpx_find_free($findhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 resource(5) of type (k2hfindhandle)
 string(5) "test1"
 resource(6) of type (k2hfindhandle)
 string(5) "test2"
 ```
+
 
 ## 参考
 - [k2hpx_find_first](k2hpx_find_firstja.html) - キー探索用ハンドルを取得する

--- a/k2hpx_get_attr_value.md
+++ b/k2hpx_get_attr_value.md
@@ -17,9 +17,11 @@ next_string: k2hpx_get_attrs
 Gets an attribute value of the key
 
 ## Description
+
 ```
 string k2hpx_get_attr_value ( mixed $handle_res , string $key , string $attrkey )
 ```
+
 Gets an attribute value of the key. 
 
 ## Parameters

--- a/k2hpx_get_attr_valueja.md
+++ b/k2hpx_get_attr_valueja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_get_attrs
 キーに設定されている属性値を取得する
 
 ## 説明
+
 ```
 string k2hpx_get_attr_value ( mixed $handle_res , string $key , string $attrkey )
 ```
+
 キーに設定されている属性値を取得します。 
 
 ## パラメータ

--- a/k2hpx_get_attrs.md
+++ b/k2hpx_get_attrs.md
@@ -17,9 +17,11 @@ next_string: k2hpx_get_subkeys
 Gets attributes of the key
 
 ## Description
+
 ```
 array k2hpx_get_attrs ( mixed $handle_res , string $key )
 ```
+
 Gets attributes of the key. 
 
 ## Parameters

--- a/k2hpx_get_attrsja.md
+++ b/k2hpx_get_attrsja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_get_subkeys
 キーに設定されている属性を取得する
 
 ## 説明
+
 ```
 array k2hpx_get_attrs ( mixed $handle_res , string $key )
 ```
+
 キーに設定されている属性を取得します。 
 
 ## パラメータ

--- a/k2hpx_get_subkeys.md
+++ b/k2hpx_get_subkeys.md
@@ -17,9 +17,11 @@ next_string: k2hpx_get_transaction_thread_pool
 Gets the array of the keys(subkeys) linked with the key
 
 ## Description
+
 ```
 array k2hpx_get_subkeys ( mixed $handle_res , string $key [, bool $attrcheck ] )
 ```
+
 Gets the array of the keys(subkeys) linked with the key. 
 
 ## Parameters

--- a/k2hpx_get_subkeysja.md
+++ b/k2hpx_get_subkeysja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_get_transaction_thread_pool
 キーに紐づけられたキー（サブキー）の一覧を取得する
 
 ## 説明
+
 ```
 array k2hpx_get_subkeys ( mixed $handle_res , string $key [, bool $attrcheck ] )
 ```
+
 キーに紐づけられたキー（サブキー）の一覧を取得します。 
 
 ## パラメータ

--- a/k2hpx_get_transaction_thread_pool.md
+++ b/k2hpx_get_transaction_thread_pool.md
@@ -17,9 +17,11 @@ next_string: k2hpx_get_value
 Gets the number of transaction workers
 
 ## Description
+
 ```
 int k2hpx_get_transaction_thread_pool ( void )
 ```
+
 Gets the number of transaction workers. 
 
 ## Parameters

--- a/k2hpx_get_transaction_thread_poolja.md
+++ b/k2hpx_get_transaction_thread_poolja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_get_value
 トランザクション処理用のスレッド数を取得する
 
 ## 説明
+
 ```
 int k2hpx_get_transaction_thread_pool ( void )
 ```
+
 トランザクション処理用のスレッド数を取得します。 
 
 ## パラメータ

--- a/k2hpx_get_value.md
+++ b/k2hpx_get_value.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_count
 Gets the value of the key
 
 ## Description
+
 ```
 string k2hpx_get_value ( mixed $handle_res , string $key [, stringnull $subkey [, bool $attrcheck [, stringnull $pass ]]] )
 ```
+
 Gets the value of the key. Gets the keys linked with the key if the key is passed. 
 
 ## Parameters

--- a/k2hpx_get_valueja.md
+++ b/k2hpx_get_valueja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_count
 キーの値を取得する
 
 ## 説明
+
 ```
 string k2hpx_get_value ( mixed $handle_res , string $key [, stringnull $subkey [, bool $attrcheck [, stringnull $pass ]]] )
 ```
+
 キーの値を取得します。キーと紐づけられたキー（サブキー）が指定された場合は、サブキーの値を取得します。 
 
 ## パラメータ

--- a/k2hpx_keyq_count.md
+++ b/k2hpx_keyq_count.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_dump
 Counts elements in the K2hKeyQueue object
 
 ## Description
+
 ```
 int k2hpx_keyq_count ( mixed $keyqhandle_res )
 ```
+
 Counts elements in the [K2hKeyQueue](k2hkq_class.html) object. 
 
 ## Parameters

--- a/k2hpx_keyq_countja.md
+++ b/k2hpx_keyq_countja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_dump
 K2hKeyQueueキューにある要素の数を取得する
 
 ## 説明
+
 ```
 int k2hpx_keyq_count ( mixed $keyqhandle_res )
 ```
+
 [K2hKeyQueue](k2hkq_classja.html) キューにある要素（キーと値のセット）の数を取得します。 
 
 ## パラメータ

--- a/k2hpx_keyq_dump.md
+++ b/k2hpx_keyq_dump.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_empty
 Gets the elements in the K2hKeyQueue object
 
 ## Description
+
 ```
 bool k2hpx_keyq_dump ( mixed $keyqhandle_res [, mixed $output ] )
 ```
+
 Gets the elements in the [K2hKeyQueue](k2hkq_class.html) object. 
 
 ## Parameters

--- a/k2hpx_keyq_dumpja.md
+++ b/k2hpx_keyq_dumpja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_empty
 K2hKeyQueueキューにある要素を表示する
 
 ## 説明
+
 ```
 bool k2hpx_keyq_dump ( mixed $keyqhandle_res [, mixed $output ] )
 ```
+
 [K2hKeyQueue](k2hkq_classja.html) キューにある要素（キーと値のセット）を表示します。 
 
 ## パラメータ

--- a/k2hpx_keyq_empty.md
+++ b/k2hpx_keyq_empty.md
@@ -32,4 +32,4 @@ Specifies the [K2hKeyQueue](k2hkq_class.html) file handle that [k2hpx_keyq_handl
 Returns true if the [K2hKeyQueue](k2hkq_class.html) object is empty, otherwise false.
 
 ## See Also
-- [K2hQueue::isEmpty](k2hq_isEmpty.html) - Returns whether the K2hQueue is empty
+- [K2hQueue::isEmpty](k2hq_isempty.html) - Returns whether the K2hQueue is empty

--- a/k2hpx_keyq_empty.md
+++ b/k2hpx_keyq_empty.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_free
 Returns whether the K2hKeyQueue is empty
 
 ## Description
+
 ```
 bool k2hpx_keyq_empty ( mixed $keyqhandle_res )
 ```
+
 Returns where the [K2hKeyQueue](k2hkq_class.html) is empty. 
 
 ## Parameters

--- a/k2hpx_keyq_emptyja.md
+++ b/k2hpx_keyq_emptyja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_free
 K2hKeyQueueキューが空かどうかを判定する
 
 ## 説明
+
 ```
 bool k2hpx_keyq_empty ( mixed $keyqhandle_res )
 ```
+
 [K2hKeyQueue](k2hkq_classja.html) キューが空かどうかを判定します。 
 
 ## パラメータ

--- a/k2hpx_keyq_emptyja.md
+++ b/k2hpx_keyq_emptyja.md
@@ -32,4 +32,4 @@ bool k2hpx_keyq_empty ( mixed $keyqhandle_res )
 [K2hKeyQueue](k2hkq_classja.html) キューが空の場合は、true。そうでなければ、false 
 
 ## 参考
-- [K2hKeyQueue::isEmpty](k2hkq_isEmptyja.html) - キューが空かどうかを判定する
+- [K2hKeyQueue::isEmpty](k2hkq_isemptyja.html) - キューが空かどうかを判定する

--- a/k2hpx_keyq_free.md
+++ b/k2hpx_keyq_free.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_handle
 Frees resources of the K2hKeyQueue handle
 
 ## Description
+
 ```
 bool k2hpx_keyq_free ( mixed $keyqhandle_res )
 ```
+
 Frees resources of the [K2hKeyQueue](k2hkq_class.html) file handle. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Frees resource of the [K2hKeyQueue](k2hkq_class.html) file handle
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -39,7 +42,10 @@ var_dump(k2hpx_keyq_free($keyqhandle));
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+

--- a/k2hpx_keyq_freeja.md
+++ b/k2hpx_keyq_freeja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_handle
 K2hKeyQueueキューハンドルを解放する
 
 ## 説明
+
 ```
 bool k2hpx_keyq_free ( mixed $keyqhandle_res )
 ```
+
 [K2hKeyQueue](k2hkq_classja.html) キューハンドルを解放します。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ bool k2hpx_keyq_free ( mixed $keyqhandle_res )
 
 ## 例
 - 例 1 - [K2hKeyQueue](k2hkq_classja.html)ハンドルを解放する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -39,7 +42,10 @@ var_dump(k2hpx_keyq_free($keyqhandle));
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+

--- a/k2hpx_keyq_handle.md
+++ b/k2hpx_keyq_handle.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_pop
 Gets the K2hKeyQueue file handle
 
 ## Description
+
 ```
 mixed k2hpx_keyq_handle ( mixed $handle_res [, bool $is_filo [, stringnull $prefix ]] )
 ```
+
 Gets the [K2hKeyQueue](k2hkq_class.html) handle. 
 
 ## Parameters
@@ -35,6 +37,7 @@ Returns the [K2hKeyQueue](k2hkq_class.html) file handle.
 
 ## Examples
 - Example 1 - Gets the [K2hKeyQueue](k2hkq_class.html) file handle
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,10 +47,13 @@ k2hpx_keyq_free($keyqhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 resource(5) of type (k2hkeyqhandle)
 ```
+
 
 ## See Also
 - [K2hQueue::__construct](k2hq_construct.html) - Creates a K2hQueue instance

--- a/k2hpx_keyq_handleja.md
+++ b/k2hpx_keyq_handleja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_pop
 K2hKeyQueueハンドルを取得する
 
 ## 説明
+
 ```
 mixed k2hpx_keyq_handle ( mixed $handle_res [, bool $is_filo [, stringnull $prefix ]] )
 ```
+
 [K2hKeyQueue](k2hkq_classja.html) ハンドルを取得します。
 
 ## パラメータ
@@ -35,6 +37,7 @@ k2hash (`.k2h`) ファイルハンドル。 [k2hpx_open](k2hpx_openja.html) 関�
 
 ## 例
 - 例 1 - [K2hKeyQueue](k2hkq_classja.html)ハンドルを取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,10 +47,13 @@ k2hpx_keyq_free($keyqhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 resource(5) of type (k2hkeyqhandle)
 ```
+
 
 ## 参考
 - [K2hKeyQueue::__construct](k2hkq_constructja.html) - 新しいK2hKeyQueueオブジェクトを作成する

--- a/k2hpx_keyq_pop.md
+++ b/k2hpx_keyq_pop.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_push
 Removes and returns the removed element from the K2hKeyQueue
 
 ## Description
+
 ```
 array k2hpx_keyq_pop ( mixed $keyqhandle_res [, stringnull $pass ] )
 ```
+
 Removes and gets the removed element from the [K2hKeyQueue](k2hkq_class.html). 
 
 ## Parameters

--- a/k2hpx_keyq_popja.md
+++ b/k2hpx_keyq_popja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_push
 K2hKeyQueueキューから要素（キーと値のセット）を取得する
 
 ## 説明
+
 ```
 array k2hpx_keyq_pop ( mixed $keyqhandle_res [, stringnull $pass ] )
 ```
+
 [K2hKeyQueue](k2hkq_classja.html) キューから要素（キーと値のセット）を取得します。 
 
 ## パラメータ

--- a/k2hpx_keyq_push.md
+++ b/k2hpx_keyq_push.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_read
 Adds a key/value pair to the K2hKeyQueue
 
 ## Description
+
 ```
 bool k2hpx_keyq_push ( mixed $keyqhandle_res , string $key , string $value [, stringnull $pass [, int $expire ]] )
 ```
+
 Adds a key/value pair to the [K2hKeyQueue](k2hkq_class.html). 
 
 ## Parameters

--- a/k2hpx_keyq_pushja.md
+++ b/k2hpx_keyq_pushja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_read
 K2hKeyQueueキューに要素（キーと値のセット）を追加する
 
 ## 説明
+
 ```
 bool k2hpx_keyq_push ( mixed $keyqhandle_res , string $key , string $value [, stringnull $pass [, int $expire ]] )
 ```
+
 [K2hKeyQueue](k2hkq_classja.html) キューに要素（キーと値のセット）を追加します。
 
 ## パラメータ

--- a/k2hpx_keyq_read.md
+++ b/k2hpx_keyq_read.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_remove
 Returns a key/value pair from the K2hKeyQueue
 
 ## Description
+
 ```
 array k2hpx_keyq_read ( mixed $keyqhandle_res [, int $pos [, stringnull $pass ]] )
 ```
+
 Returns a key/value pair from the [K2hKeyQueue](k2hkq_class.html). This operation will not remove the key/value pair from the [K2hKeyQueue](k2hkq_class.html). 
 
 ### Note

--- a/k2hpx_keyq_readja.md
+++ b/k2hpx_keyq_readja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_keyq_remove
 K2hKeyQueueキューの要素（キーと値のセット）を表示する
 
 ## 説明
+
 ```
 array k2hpx_keyq_read ( mixed $keyqhandle_res [, int $pos [, stringnull $pass ]] )
 ```
+
 [K2hKeyQueue](k2hkq_classja.html) キューの要素（キーと値のセット）を表示します。キューから要素は削除されません。 
 
 ### 注意

--- a/k2hpx_keyq_remove.md
+++ b/k2hpx_keyq_remove.md
@@ -17,9 +17,11 @@ next_string: k2hpx_load_archive
 Removes a key/value pair from the K2hKeyQueue
 
 ## Description
+
 ```
 bool k2hpx_keyq_remove ( mixed $keyqhandle_res , int $count [, stringnull $pass ] )
 ```
+
 Removes a key/value pair from the [K2hKeyQueue](k2hkq_class.html). 
 
 ## Parameters

--- a/k2hpx_keyq_removeja.md
+++ b/k2hpx_keyq_removeja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_load_archive
 K2hKeyQueueキューから要素（キーと値のセット）を削除する
 
 ## 説明
+
 ```
 bool k2hpx_keyq_remove ( mixed $keyqhandle_res , int $count [, stringnull $pass ] )
 ```
+
 [K2hKeyQueue](k2hkq_classja.html) キューから要素（キーと値のセット）を削除します。 
 
 ## パラメータ

--- a/k2hpx_load_archive.md
+++ b/k2hpx_load_archive.md
@@ -17,9 +17,11 @@ next_string: k2hpx_load_debug_env
 Loads data from the file
 
 ## Description
+
 ```
 bool k2hpx_load_archive ( mixed $handle_res , string $filepath [, bool $errskip ] )
 ```
+
 Loads data from the file. The file should be either a transaction file or an archive file.
 
 ## Parameters

--- a/k2hpx_load_archiveja.md
+++ b/k2hpx_load_archiveja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_load_debug_env
 ファイルからデータをロードする
 
 ## 説明
+
 ```
 bool k2hpx_load_archive ( mixed $handle_res , string $filepath [, bool $errskip ] )
 ```
+
 トランザクションファイルまたはアーカイブファイルからデータをロードします。 
 
 ## パラメータ

--- a/k2hpx_load_debug_env.md
+++ b/k2hpx_load_debug_env.md
@@ -17,9 +17,11 @@ next_string: k2hpx_load_hash_library
 Loads environment variables
 
 ## Description
+
 ```
 bool k2hpx_load_debug_env ( void )
 ```
+
 Loads environment variables.
 
 ## Parameters
@@ -30,12 +32,16 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Loads environment variables
+
 ```
 <?php
 var_dump(k2hpx_load_debug_env());
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+

--- a/k2hpx_load_debug_envja.md
+++ b/k2hpx_load_debug_envja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_load_hash_library
 環境変数を読み込む
 
 ## 説明
+
 ```
 bool k2hpx_load_debug_env ( void )
 ```
+
 環境変数を読み込みます。 
 
 ## パラメータ
@@ -30,12 +32,16 @@ bool k2hpx_load_debug_env ( void )
 
 ## 例
 - 例 1 - 環境変数を読み込む
+
 ```
 <?php
 var_dump(k2hpx_load_debug_env());
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+

--- a/k2hpx_load_hash_library.md
+++ b/k2hpx_load_hash_library.md
@@ -17,9 +17,11 @@ next_string: k2hpx_load_transaction_library
 Loads hash functions from the file
 
 ## Description
+
 ```
 bool k2hpx_load_hash_library ( string $libpath )
 ```
+
 Loads hash functions from the file. 
 
 ## Parameters
@@ -31,15 +33,19 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Loads hash functions from the file
+
 ```
 <?php
 var_dump(k2hpx_load_hash_library("/usr/lib/libk2htest.so"));
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+
 
 ## See Also
 - [k2hpx_unload_hash_library](k2hpx_unload_hash_library.html) - Removes the user-defined hash library

--- a/k2hpx_load_hash_libraryja.md
+++ b/k2hpx_load_hash_libraryja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_load_transaction_library
 ハッシュ関数を有効にする
 
 ## 説明
+
 ```
 bool k2hpx_load_hash_library ( string $libpath )
 ```
+
 ハッシュ関数を有効にします。 
 
 ## パラメータ
@@ -31,15 +33,19 @@ bool k2hpx_load_hash_library ( string $libpath )
 
 ## 例
 - 例 1 - ハッシュ関数用ライブラリを読み込む
+
 ```
 <?php
 var_dump(k2hpx_load_hash_library("/usr/lib/libk2htest.so"));
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+
 
 ## 参考
 - [k2hpx_unload_hash_library](k2hpx_unload_hash_libraryja.html) - ハッシュ関数ライブラリを取り外す

--- a/k2hpx_load_transaction_library.md
+++ b/k2hpx_load_transaction_library.md
@@ -17,9 +17,11 @@ next_string: k2hpx_open_mem
 Loads functions of k2hash transaction usage from the file
 
 ## Description
+
 ```
 bool k2hpx_load_transaction_library ( string $libpath )
 ```
+
 Loads functions of k2hash transaction usage from the file. 
 
 ## Parameters
@@ -31,15 +33,19 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Loads functions of k2hash transaction usage from the file
+
 ```
 <?php
 var_dump(k2hpx_load_transaction_library("/usr/lib/libk2htestlib.so"));
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+
 
 ## See Also
 - [k2hpx_unload_transaction_library](k2hpx_unload_transaction_library.html) - Removes the user-defined transaction library

--- a/k2hpx_load_transaction_libraryja.md
+++ b/k2hpx_load_transaction_libraryja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_open_mem
 トランザクション用ライブラリを読み込む
 
 ## 説明
+
 ```
 bool k2hpx_load_transaction_library ( string $libpath )
 ```
+
 
 
 ## パラメータ
@@ -31,15 +33,19 @@ bool k2hpx_load_transaction_library ( string $libpath )
 
 ## 例
 - 例 1 - トランザクション用ライブラリを読み込む
+
 ```
 <?php
 var_dump(k2hpx_load_transaction_library("/usr/lib/libk2htestlib.so"));
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+
 
 ## 参考
 - [k2hpx_unload_transaction_library](k2hpx_unload_transaction_libraryja.html) - トランザクション用ライブラリを無効にする

--- a/k2hpx_open.md
+++ b/k2hpx_open.md
@@ -17,9 +17,11 @@ next_string: k2hpx_print_attr_information
 Opens the k2hash file
 
 ## Description
+
 ```
 mixed k2hpx_open ( string $filepath , bool $readonly [, bool $removefile [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]]] )
 ```
+
 Opens the k2hash (`.k2h`) file.
 
 ## Parameters

--- a/k2hpx_open_mem.md
+++ b/k2hpx_open_mem.md
@@ -17,9 +17,11 @@ next_string: k2hpx_open_ro
 Opens k2hash as volatile(on memory).
 
 ## Description
+
 ```
 mixed k2hpx_open_mem ([ int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]] )
 ```
+
 Opens k2hash as volatile(on memory).
 
 ## Parameters

--- a/k2hpx_open_memja.md
+++ b/k2hpx_open_memja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_open_ro
 揮発性（メモリ）としてk2hashをオープンします。
 
 ## 説明
+
 ```
 mixed k2hpx_open_mem ([ int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]] )
 ```
+
 揮発性（メモリ）としてk2hashをオープンします。
 
 ## パラメータ

--- a/k2hpx_open_ro.md
+++ b/k2hpx_open_ro.md
@@ -17,9 +17,11 @@ next_string: k2hpx_open_rw
 Read the k2hash file
 
 ## Description
+
 ```
 mixed k2hpx_open_ro ( string $filepath [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]] )
 ```
+
 Opens the the k2hash (`.k2h`) file with read only access.
 
 ## Parameters

--- a/k2hpx_open_roja.md
+++ b/k2hpx_open_roja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_open_rw
 k2hashファイルを読み出し用にオープンする
 
 ## 説明
+
 ```
 mixed k2hpx_open_ro ( string $filepath [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]] )
 ```
+
 読み取り専用でk2hashファイルを開きます。
 
 ## パラメータ

--- a/k2hpx_open_rw.md
+++ b/k2hpx_open_rw.md
@@ -17,9 +17,11 @@ next_string: k2hpx_open_tempfile
 Opens the k2hash file with read and write access
 
 ## Description
+
 ```
 mixed k2hpx_open_rw ( string $filepath [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]] )
 ```
+
 Opens the the k2hash (`.k2h`) file with read and write access. 
 
 ## Parameters

--- a/k2hpx_open_rwja.md
+++ b/k2hpx_open_rwja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_open_tempfile
 k2hashファイルを編集用にオープンする
 
 ## 説明
+
 ```
 mixed k2hpx_open_rw ( string $filepath [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]] )
 ```
+
 編集可能な状態でk2hashファイルを開きます。 
 
 ## パラメータ

--- a/k2hpx_open_tempfile.md
+++ b/k2hpx_open_tempfile.md
@@ -17,9 +17,11 @@ next_string: k2hpx_open
 Opens the k2hash file with read and write access on a temporary file system
 
 ## Description
+
 ```
 mixed k2hpx_open_tempfile ( string $filepath [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]] )
 ```
+
 Opens the the k2hash (`.k2h`) file with read and write access on a temporary file system. 
 
 ## Parameters

--- a/k2hpx_open_tempfileja.md
+++ b/k2hpx_open_tempfileja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_open
 一時ファイルとしてk2hashファイルをオープンする
 
 ## 説明
+
 ```
 mixed k2hpx_open_tempfile ( string $filepath [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]] )
 ```
+
 一時ファイルとして、k2hashファイルを開きます。 
 
 ## パラメータ

--- a/k2hpx_openja.md
+++ b/k2hpx_openja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_print_attr_information
 k2hashファイルを開く
 
 ## 説明
+
 ```
 mixed k2hpx_open ( string $filepath , bool $readonly [, bool $removefile [, bool $fullmap [, int $maskbitcnt [, int $cmaskbitcnt [, int $maxelementcnt [, int $pagesize ]]]]]] )
 ```
+
 k2hashファイルを開きます。 
 
 ## パラメータ

--- a/k2hpx_print_attr_information.md
+++ b/k2hpx_print_attr_information.md
@@ -17,9 +17,11 @@ next_string: k2hpx_print_attr_version
 Prints the attribute information
 
 ## Description
+
 ```
 bool k2hpx_print_attr_information ( mixed $handle_res [, mixed $output ] )
 ```
+
 Prints the attribute information. 
 
 ## Parameters
@@ -33,6 +35,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Prints the attribute information
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -42,7 +45,10 @@ fclose($fp);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 K2HASH attribute libraries:  K2H ATTR BUILTIN
 ```
+

--- a/k2hpx_print_attr_informationja.md
+++ b/k2hpx_print_attr_informationja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_print_attr_version
 属性情報を表示する
 
 ## 説明
+
 ```
 bool k2hpx_print_attr_information ( mixed $handle_res [, mixed $output ] )
 ```
+
 属性情報を表示します。 
 
 ## パラメータ
@@ -33,6 +35,7 @@ k2hash (`.k2h`) ファイルハンドル。 [k2hpx_open](k2hpx_openja.html) 関�
 
 ## 例
 - 例 1 - 属性情報を表示する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -42,7 +45,10 @@ fclose($fp);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 K2HASH attribute libraries:  K2H ATTR BUILTIN
 ```
+

--- a/k2hpx_print_attr_version.md
+++ b/k2hpx_print_attr_version.md
@@ -17,9 +17,11 @@ next_string: k2hpx_print_state
 Prints the attribute library version
 
 ## Description
+
 ```
 bool k2hpx_print_attr_version ( mixed $handle_res [, mixed $output ] )
 ```
+
 Prints the attribute library version. 
 
 ## Parameters

--- a/k2hpx_print_attr_versionja.md
+++ b/k2hpx_print_attr_versionja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_print_state
 属性のライブラリバージョン情報を表示する
 
 ## 説明
+
 ```
 bool k2hpx_print_attr_version ( mixed $handle_res [, mixed $output ] )
 ```
+
 属性のライブラリバージョン情報を表示します。 
 
 ## パラメータ

--- a/k2hpx_print_state.md
+++ b/k2hpx_print_state.md
@@ -17,9 +17,11 @@ next_string: k2hpx_print_version
 Prints k2hash data statistics
 
 ## Description
+
 ```
 bool k2hpx_print_state ( mixed $handle_res [, mixed $output ] )
 ```
+
 Prints k2hash data statistics. 
 
 ## Parameters

--- a/k2hpx_print_stateja.md
+++ b/k2hpx_print_stateja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_print_version
 k2hashのデータの状態を表示する
 
 ## 説明
+
 ```
 bool k2hpx_print_state ( mixed $handle_res [, mixed $output ] )
 ```
+
 k2hashのデータの状態を表示します。 
 
 ## パラメータ

--- a/k2hpx_print_version.md
+++ b/k2hpx_print_version.md
@@ -17,9 +17,11 @@ next_string: k2hpx_put_archive
 Prints the library version
 
 ## Description
+
 ```
 bool k2hpx_print_version ([ mixed $output ] )
 ```
+
 Prints the library version. 
 
 ## Parameters

--- a/k2hpx_print_versionja.md
+++ b/k2hpx_print_versionja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_put_archive
 ライブラリのバージョンなどを表示する
 
 ## 説明
+
 ```
 bool k2hpx_print_version ([ mixed $output ] )
 ```
+
 k2hashライブラリのバージョンおよびクレジットを表示します。
 
 ## パラメータ

--- a/k2hpx_put_archive.md
+++ b/k2hpx_put_archive.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_count
 Saves a k2hash file as an archive file
 
 ## Description
+
 ```
 bool k2hpx_put_archive ( mixed $handle_res , string $filepath [, bool $errskip ] )
 ```
+
 Saves the k2hash (`.k2h`) file as an archive file. 
 
 ## Parameters

--- a/k2hpx_put_archiveja.md
+++ b/k2hpx_put_archiveja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_count
 k2hashファイルをアーカイブファイルとして保存する
 
 ## 説明
+
 ```
 bool k2hpx_put_archive ( mixed $handle_res , string $filepath [, bool $errskip ] )
 ```
+
 k2hashファイルをアーカイブファイルとして保存します。 
 
 ## パラメータ

--- a/k2hpx_q_count.md
+++ b/k2hpx_q_count.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_dump
 Counts elements in the K2hQueue object
 
 ## Description
+
 ```
 int k2hpx_q_count ( mixed $qhandle_res )
 ```
+
 Counts elements in the [K2hQueue](k2hq_class.html) object. 
 
 ## Parameters

--- a/k2hpx_q_countja.md
+++ b/k2hpx_q_countja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_dump
 K2hQueueキューにある要素の数を取得する
 
 ## 説明
+
 ```
 int k2hpx_q_count ( mixed $qhandle_res )
 ```
+
 [K2hQueue](k2hq_classja.html)キューにある要素の数を取得します。 
 
 ## パラメータ

--- a/k2hpx_q_dump.md
+++ b/k2hpx_q_dump.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_empty
 Prints the elements in the K2hQueue object
 
 ## Description
+
 ```
 bool k2hpx_q_dump ( mixed $qhandle_res [, mixed $output ] )
 ```
+
 Prints the elements in the [K2hQueue](k2hq_class.html) object. 
 
 ## Parameters

--- a/k2hpx_q_dumpja.md
+++ b/k2hpx_q_dumpja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_empty
 K2hQueueキューにある要素を表示する
 
 ## 説明
+
 ```
 bool k2hpx_q_dump ( mixed $qhandle_res [, mixed $output ] )
 ```
+
 [K2hQueue](k2hq_classja.html)キューにある要素を表示します。 
 
 ## パラメータ

--- a/k2hpx_q_empty.md
+++ b/k2hpx_q_empty.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_free
 Returns whether the K2hQueue is empty
 
 ## Description
+
 ```
 bool k2hpx_q_empty ( mixed $qhandle_res )
 ```
+
 Returns where the [K2hQueue](k2hq_class.html) is empty. 
 
 ## Parameters

--- a/k2hpx_q_empty.md
+++ b/k2hpx_q_empty.md
@@ -32,4 +32,4 @@ Specifies the [K2hQueue](k2hq_class.html) file handle that [k2hpx_q_handle](k2hp
 Returns true if the [K2hQueue](k2hq_class.html) object is empty, otherwise false.
 
 ## See Also
-- [K2hQueue::isEmpty](k2hq_isEmpty.html) - Returns whether the K2hQueue is empty
+- [K2hQueue::isEmpty](k2hq_isempty.html) - Returns whether the K2hQueue is empty

--- a/k2hpx_q_emptyja.md
+++ b/k2hpx_q_emptyja.md
@@ -32,4 +32,4 @@ bool k2hpx_q_empty ( mixed $qhandle_res )
 [K2hQueue](k2hq_classja.html) キューが空の場合は、true。そうでなければ、false 
 
 ## 参考
-- [K2hQueue::isEmpty](k2hq_isEmptyja.html) - キューが空かどうかを判定する
+- [K2hQueue::isEmpty](k2hq_isemptyja.html) - キューが空かどうかを判定する

--- a/k2hpx_q_emptyja.md
+++ b/k2hpx_q_emptyja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_free
 K2hQueueキューが空かどうかを判定する
 
 ## 説明
+
 ```
 bool k2hpx_q_empty ( mixed $qhandle_res )
 ```
+
 [K2hQueue](k2hq_classja.html) キューが空かどうかを判定します。 
 
 ## パラメータ

--- a/k2hpx_q_free.md
+++ b/k2hpx_q_free.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_handle
 Frees resources of the K2hQueue handle
 
 ## Description
+
 ```
 bool k2hpx_q_free ( mixed $qhandle_res )
 ```
+
 Frees resources of the [K2hQueue](k2hq_class.html) file handle. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Frees resource of the [K2hQueue](k2hq_class.html) file handle
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -39,7 +42,10 @@ var_dump(k2hpx_q_free($qhandle));
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+

--- a/k2hpx_q_freeja.md
+++ b/k2hpx_q_freeja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_handle
 K2hQueueキューハンドルを解放する
 
 ## 説明
+
 ```
 bool k2hpx_q_free ( mixed $qhandle_res )
 ```
+
 [K2hQueue](k2hq_classja.html)キューハンドルを解放します。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ bool k2hpx_q_free ( mixed $qhandle_res )
 
 ## 例
 - 例 1 - [K2hQueue](k2hq_classja.html)ハンドルを解放する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -39,7 +42,10 @@ var_dump(k2hpx_q_free($qhandle));
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+

--- a/k2hpx_q_handle.md
+++ b/k2hpx_q_handle.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_pop
 Gets the K2hQueue file handle
 
 ## Description
+
 ```
 mixed k2hpx_q_handle ( mixed $handle_res [, bool $is_filo [, stringnull $prefix ]] )
 ```
+
 Gets the [K2hQueue](k2hq_class.html) handle. 
 
 ## Parameters
@@ -35,6 +37,7 @@ Returns the [K2hQueue](k2hq_class.html) file handle.
 
 ## Examples
 - Example 1 - Gets the [K2hQueue](k2hq_class.html) file handle
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,10 +47,13 @@ k2hpx_q_free($qhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 resource(5) of type (k2hqhandle)
 ```
+
 
 ## See Also
 - [K2hQueue::__construct](k2hq_construct.html) - Creates a K2hQueue instance

--- a/k2hpx_q_handleja.md
+++ b/k2hpx_q_handleja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_pop
 K2hQueueハンドルを取得する
 
 ## 説明
+
 ```
 mixed k2hpx_q_handle ( mixed $handle_res [, bool $is_filo [, stringnull $prefix ]] )
 ```
+
 [K2hQueue](k2hq_classja.html) ハンドルを取得します。
 
 ## パラメータ
@@ -35,6 +37,7 @@ k2hash (`.k2h`) ファイルハンドル。 [k2hpx_open](k2hpx_openja.html) 関�
 
 ## 例
 - 例 1 - [K2hQueue](k2hq_classja.html)ハンドルを取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -44,10 +47,13 @@ k2hpx_q_free($qhandle);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 resource(5) of type (k2hqhandle)
 ```
+
 
 ## 参考
 - [K2hQueue::__construct](k2hq_constructja.html) - 新しいK2hQueueオブジェクトを作成する

--- a/k2hpx_q_pop.md
+++ b/k2hpx_q_pop.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_push
 Removes and returns the removed element from the K2hQueue
 
 ## Description
+
 ```
 string 2hpx_q_pop ( mixed $qhandle_res [, stringnull $pass ] )
 ```
+
 Removes and gets the removed element from the [K2hQueue](k2hq_class.html). 
 
 ## Parameters

--- a/k2hpx_q_popja.md
+++ b/k2hpx_q_popja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_push
 K2hQueueキューから要素を取得する
 
 ## 説明
+
 ```
 string k2hpx_q_pop ( mixed $qhandle_res [, stringnull $pass ] )
 ```
+
 [K2hQueue](k2hq_classja.html) キューから要素を取得します。 
 
 ## パラメータ

--- a/k2hpx_q_push.md
+++ b/k2hpx_q_push.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_read
 Adds a value to the K2hQueue
 
 ## Description
+
 ```
 bool k2hpx_q_push ( mixed $qhandle_res , string $datavalue [, stringnull $pass [, int $expire ]] )
 ```
+
 Adds a value to the [K2hQueue](k2hq_class.html). 
 
 ## Parameters

--- a/k2hpx_q_pushja.md
+++ b/k2hpx_q_pushja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_read
 K2hQueueキューに要素を追加する
 
 ## 説明
+
 ```
 bool k2hpx_q_push ( mixed $qhandle_res , string $datavalue [, stringnull $pass [, int $expire ]] )
 ```
+
 [K2hQueue](k2hq_classja.html) キューに要素を追加します。
 
 ## パラメータ

--- a/k2hpx_q_pushja.md
+++ b/k2hpx_q_pushja.md
@@ -38,4 +38,4 @@ bool k2hpx_q_push ( mixed $qhandle_res , string $datavalue [, stringnull $pass [
 成功時は、true。それ以外の場合は、false
 
 ## 参考
-- [K2hQueue::push](k2hq_push.html) - Adds a value to the K2hQueue
+- [K2hQueue::push](k2hq_pushja.html) - キューに要素を追加する

--- a/k2hpx_q_read.md
+++ b/k2hpx_q_read.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_remove
 Returns a key/value pair from the K2hQueue
 
 ## Description
+
 ```
 string k2hpx_q_read ( mixed $qhandle_res [, int $pos [, stringnull $pass ]] )
 ```
+
 Returns a value from the [K2hQueue](k2hq_class.html). This operation will not remove the value from the [K2hQueue](k2hq_class.html). 
 
 ### Note

--- a/k2hpx_q_readja.md
+++ b/k2hpx_q_readja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_q_remove
 K2hQueueキューの要素（値）を表示する
 
 ## 説明
+
 ```
 string k2hpx_q_read ( mixed $qhandle_res [, int $pos [, stringnull $pass ]] )
 ```
+
 [K2hQueue](k2hq_classja.html) キューの要素（値）を表示します。 
 
 ### 注意

--- a/k2hpx_q_remove.md
+++ b/k2hpx_q_remove.md
@@ -17,9 +17,11 @@ next_string: k2hpx_remove_all
 Removes a value from the K2hQueue
 
 ## Description
+
 ```
 bool k2hpx_q_remove ( mixed $qhandle_res , int $count [, stringnull $pass ] )
 ```
+
 Removes a value from the [K2hQueue](k2hq_class.html). 
 
 ## Parameters

--- a/k2hpx_q_removeja.md
+++ b/k2hpx_q_removeja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_remove_all
 K2hQueueキューから要素を削除する
 
 ## 説明
+
 ```
 bool k2hpx_q_remove ( mixed $qhandle_res , int $count [, stringnull $pass ] )
 ```
+
 [K2hQueue](k2hq_classja.html) キューから要素（値）を削除します。 
 
 ## パラメータ

--- a/k2hpx_remove.md
+++ b/k2hpx_remove.md
@@ -17,9 +17,11 @@ next_string: k2hpx_rename
 Removes the key
 
 ## Description
+
 ```
 bool k2hpx_remove ( mixed $handle_res , string $key [, stringnull $subkey ] )
 ```
+
 Removes the key. 
 
 ## Parameters

--- a/k2hpx_remove_all.md
+++ b/k2hpx_remove_all.md
@@ -17,9 +17,11 @@ next_string: k2hpx_remove
 Removes the key and the keys linked with the key
 
 ## Description
+
 ```
 bool k2hpx_remove_all ( mixed $handle_res , string $key )
 ```
+
 Removes the key and the keys linked with the key. 
 
 ## Parameters

--- a/k2hpx_remove_allja.md
+++ b/k2hpx_remove_allja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_remove
 キーと、キーに紐づけられているキー（サブキー）を削除する
 
 ## 説明
+
 ```
 bool k2hpx_remove_all ( mixed $handle_res , string $key )
 ```
+
 キーと、キーに紐づけられているキー（サブキー）を削除します。 
 
 ## パラメータ

--- a/k2hpx_removeja.md
+++ b/k2hpx_removeja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_rename
 キーを削除する
 
 ## 説明
+
 ```
 bool k2hpx_remove ( mixed $handle_res , string $key [, stringnull $subkey ] )
 ```
+
 キーを削除します。キーに紐づけられたキーをサブキーと呼びます。サブキーに紐づけられたキーを親キーと呼びます。  
 親キーのみを指定した場合は、サブキーは削除されません。  
 サブキーを指定した場合は、サブキーは削除され、親キーは削除されません。  

--- a/k2hpx_rename.md
+++ b/k2hpx_rename.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_common_attr
 Renames the key
 
 ## Description
+
 ```
 bool k2hpx_rename ( mixed $handle_res , string $key , string $newkey )
 ```
+
 Renames the key. 
 
 ## Parameters

--- a/k2hpx_renameja.md
+++ b/k2hpx_renameja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_common_attr
 キー名を変更する
 
 ## 説明
+
 ```
 bool k2hpx_rename ( mixed $handle_res , string $key , string $newkey )
 ```
+
 キー名を変更します。 
 
 ## パラメータ

--- a/k2hpx_set_common_attr.md
+++ b/k2hpx_set_common_attr.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_debug_file
 Sets the common attributes
 
 ## Description
+
 ```
 bool k2hpx_set_common_attr ( mixed $handle_res [, int $is_mtime [, int $is_history [, int $is_encrypt [, stringnull $passfile [, int $is_expire [, int $expire ]]]]]] )
 ```
+
 Sets the common attributes. 
 
 ## Parameters

--- a/k2hpx_set_common_attrja.md
+++ b/k2hpx_set_common_attrja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_debug_file
 キーの基本属性を設定する
 
 ## 説明
+
 ```
 bool k2hpx_set_common_attr ( mixed $handle_res [, int $is_mtime [, int $is_history [, int $is_encrypt [, stringnull $passfile [, int $is_expire [, int $expire ]]]]]] )
 ```
+
 キーの基本属性を設定します。 
 
 ## パラメータ

--- a/k2hpx_set_debug_file.md
+++ b/k2hpx_set_debug_file.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_debug_level_error
 Writes log to the file
 
 ## Description
+
 ```
 bool k2hpx_set_debug_file ( string $filepath )
 ```
+
 Writes log to the file. 
 
 ## Parameters
@@ -31,15 +33,19 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Write log to a file
+
 ```
 <?php
 var_dump(k2hpx_set_debug_file("/tmp/k2h.log"));
 ?>
 ```
+
 The above example will output:
+
 ```
 NULL
 ```
+
 
 ## See Also
 - [k2hpx_bump_debug_level](k2hpx_bump_debug_level.html) - Changes the log level

--- a/k2hpx_set_debug_fileja.md
+++ b/k2hpx_set_debug_fileja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_debug_level_error
 ログ出力先ファイル名を指定する
 
 ## 説明
+
 ```
 bool k2hpx_set_debug_file ( string $filepath )
 ```
+
 ログ出力先ファイル名を指定します。 
 
 ## パラメータ
@@ -31,15 +33,19 @@ bool k2hpx_set_debug_file ( string $filepath )
 
 ## 例
 - 例 1 - ログファイル名を指定する
+
 ```
 <?php
 var_dump(k2hpx_set_debug_file("/tmp/k2h.log"));
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 NULL
 ```
+
 
 ## 参考
 - [k2hpx_bump_debug_level](k2hpx_bump_debug_levelja.html) - ログレベルを変更する

--- a/k2hpx_set_debug_level_error.md
+++ b/k2hpx_set_debug_level_error.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_debug_level_message
 Sets log level to error
 
 ## Description
+
 ```
 void k2hpx_set_debug_level_error ( void )
 ```
+
 Sets log level to 'error' level. 
 
 ## Parameters
@@ -30,16 +32,20 @@ No value is returned.
 
 ## Examples
 - Example 1 - Sets debug level to error
+
 ```
 <?php
 var_dump(k2hpx_set_debug_file("/tmp/k2h.log"));
 k2hpx_set_debug_level_error();
 ?>
 ```
+
 The above example will output:
+
 ```
 NULL
 ```
+
 
 ## See Also
 - [k2hpx_bump_debug_level](k2hpx_bump_debug_level.html) - Changes the log level

--- a/k2hpx_set_debug_level_errorja.md
+++ b/k2hpx_set_debug_level_errorja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_debug_level_message
 ライブラリのログレベルをerrorにする
 
 ## 説明
+
 ```
 void k2hpx_set_debug_level_error ( void )
 ```
+
 k2hashライブラリのログレベルをerrorにします。 
 
 ## パラメータ
@@ -30,16 +32,20 @@ k2hashライブラリのログレベルをerrorにします。
 
 ## 例
 - 例 1 - ライブラリのログレベルをerrorにする
+
 ```
 <?php
 var_dump(k2hpx_set_debug_file("/tmp/k2h.log"));
 k2hpx_set_debug_level_error();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 NULL
 ```
+
 
 ## 参考
 - [k2hpx_bump_debug_level](k2hpx_bump_debug_levelja.html) - ログレベルを変更する

--- a/k2hpx_set_debug_level_message.md
+++ b/k2hpx_set_debug_level_message.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_debug_level_silent
 Sets log level to info
 
 ## Description
+
 ```
 void k2hpx_set_debug_level_message ( void )
 ```
+
 Sets log level to 'message' (info) level. 
 
 ## Parameters
@@ -30,16 +32,20 @@ No value is returned.
 
 ## Examples
 - Example 1 - Set log level to info
+
 ```
 <?php
 var_dump(k2hpx_set_debug_file("/tmp/k2h.log"));
 k2hpx_set_debug_level_message();
 ?>
 ```
+
 The above example will output:
+
 ```
 NULL
 ```
+
 
 ## See Also
 - [k2hpx_bump_debug_level](k2hpx_bump_debug_level.html) - Changes the log level

--- a/k2hpx_set_debug_level_messageja.md
+++ b/k2hpx_set_debug_level_messageja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_debug_level_silent
 ライブラリのログレベルをmessage(info相当）にする
 
 ## 説明
+
 ```
 void k2hpx_set_debug_level_message ( void )
 ```
+
 ライブラリのログレベルをmessage(info相当）にします。 
 
 ## パラメータ
@@ -30,16 +32,20 @@ void k2hpx_set_debug_level_message ( void )
 
 ## 例
 - 例 1 - ライブラリのログレベルをmessageにする
+
 ```
 <?php
 var_dump(k2hpx_set_debug_file("/tmp/k2h.log"));
 k2hpx_set_debug_level_message();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 NULL
 ```
+
 
 ## 参考
 - [k2hpx_bump_debug_level](k2hpx_bump_debug_levelja.html) - ログレベルを変更する

--- a/k2hpx_set_debug_level_silent.md
+++ b/k2hpx_set_debug_level_silent.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_debug_level_warning
 Sets log level to silent
 
 ## Description
+
 ```
 void k2hpx_set_debug_level_silent ( void )
 ```
+
 Sets log level to silent.
 
 ## Parameters
@@ -30,16 +32,20 @@ No value is returned.
 
 ## Examples
 - Example 1 - Sets log level to silent
+
 ```
 <?php
 var_dump(k2hpx_set_debug_file("/tmp/k2h.log"));
 k2hpx_set_debug_level_silent();
 ?>
 ```
+
 The above example will output:
+
 ```
 NULL
 ```
+
 
 ## See Also
 - [k2hpx_bump_debug_level](k2hpx_bump_debug_level.html) - Changes the log level

--- a/k2hpx_set_debug_level_silentja.md
+++ b/k2hpx_set_debug_level_silentja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_debug_level_warning
 ライブラリのログレベルをSilentにする
 
 ## 説明
+
 ```
 void k2hpx_set_debug_level_silent ( void )
 ```
+
 ライブラリのログレベルをSilentにする。
 
 
@@ -31,16 +33,20 @@ void k2hpx_set_debug_level_silent ( void )
 
 ## 例
 - 例 1 - ライブラリのログレベルをSilentにする
+
 ```
 <?php
 var_dump(k2hpx_set_debug_file("/tmp/k2h.log"));
 k2hpx_set_debug_level_silent();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 NULL
 ```
+
 
 ## 参考
 - [k2hpx_bump_debug_level](k2hpx_bump_debug_levelja.html) - ログレベルを変更する

--- a/k2hpx_set_debug_level_warning.md
+++ b/k2hpx_set_debug_level_warning.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_transaction_thread_pool
 Sets log level to warning
 
 ## Description
+
 ```
 void k2hpx_set_debug_level_warning ( void )
 ```
+
 Sets log level to 'warning level. 
 
 ## Parameters
@@ -30,16 +32,20 @@ No value is returned.
 
 ## Examples
 - Example 1 - Sets log level to warning
+
 ```
 <?php
 var_dump(k2hpx_set_debug_file("/tmp/k2h.log"));
 k2hpx_set_debug_level_warning();
 ?>
 ```
+
 The above example will output:
+
 ```
 NULL
 ```
+
 
 ## See Also
 - [k2hpx_bump_debug_level](k2hpx_bump_debug_level.html) - Changes the log level

--- a/k2hpx_set_debug_level_warningja.md
+++ b/k2hpx_set_debug_level_warningja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_transaction_thread_pool
 ライブラリのログレベルをwarningにする
 
 ## 説明
+
 ```
 void k2hpx_set_debug_level_warning ( void )
 ```
+
 ライブラリのログレベルをwarningにします。
 
 ## パラメータ
@@ -30,16 +32,20 @@ void k2hpx_set_debug_level_warning ( void )
 
 ## 例
 - 例 1 - ライブラリのログレベルをwarningにする
+
 ```
 <?php
 var_dump(k2hpx_set_debug_file("/tmp/k2h.log"));
 k2hpx_set_debug_level_warning();
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 NULL
 ```
+
 
 ## 参考
 - [k2hpx_bump_debug_level](k2hpx_bump_debug_levelja.html) - ログレベルを変更する

--- a/k2hpx_set_transaction_thread_pool.md
+++ b/k2hpx_set_transaction_thread_pool.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_value
 Sets the number of transaction workers
 
 ## Description
+
 ```
 bool k2hpx_set_transaction_thread_pool ( int $count )
 ```
+
 Sets the number of transaction workers. 
 
 ## Parameters

--- a/k2hpx_set_transaction_thread_poolja.md
+++ b/k2hpx_set_transaction_thread_poolja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_set_value
 トランザクション処理用のスレッド数を設定する
 
 ## 説明
+
 ```
 bool k2hpx_set_transaction_thread_pool ( int $count )
 ```
+
 トランザクション処理用のスレッド数を設定します。 
 
 ## パラメータ

--- a/k2hpx_set_value.md
+++ b/k2hpx_set_value.md
@@ -17,9 +17,11 @@ next_string: k2hpx_transaction
 Sets the value
 
 ## Description
+
 ```
 bool k2hpx_set_value ( mixed $handle_res , string $key , string $value [, stringnull $subkey [, stringnull $pass [, int $expire ]]] )
 ```
+
 Sets the value to the key. 
 
 ## Parameters

--- a/k2hpx_set_valueja.md
+++ b/k2hpx_set_valueja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_transaction
 キーに値を設定する
 
 ## 説明
+
 ```
 bool k2hpx_set_value ( mixed $handle_res , string $key , string $value [, stringnull $subkey [, stringnull $pass [, int $expire ]]] )
 ```
+
 キーに値を設定します。 
 
 ## パラメータ

--- a/k2hpx_transaction.md
+++ b/k2hpx_transaction.md
@@ -17,9 +17,11 @@ next_string: k2hpx_unload_hash_library
 Changes transaction settings
 
 ## Description
+
 ```
 bool k2hpx_transaction ( mixed $handle_res , bool $enable [, stringnull $transfile [, stringnull $prefix [, stringnull $param [, int $expire ]]]] )
 ```
+
 Changes transaction settings. 
 
 ## Parameters
@@ -41,4 +43,3 @@ Returns true on success or false on failure..
 
 ## See Also
 - [K2hash::transaction](k2h_transaction.html) - Changes transaction settings
-s

--- a/k2hpx_transactionja.md
+++ b/k2hpx_transactionja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_unload_hash_library
 トランザクションを有効また無効にする
 
 ## 説明
+
 ```
 bool k2hpx_transaction ( mixed $handle_res , bool $enable [, stringnull $transfile [, stringnull $prefix [, stringnull $param [, int $expire ]]]] )
 ```
+
 トランザクションを有効また無効にする。 
 
 ## パラメータ
@@ -41,4 +43,3 @@ k2hash (`.k2h`) ファイルハンドル。 [k2hpx_open](k2hpx_openja.html) 関�
 
 ## 参考
 - [K2hash::transaction](k2h_transactionja.html) - トランザクションを有効また無効にする
-s

--- a/k2hpx_unload_hash_library.md
+++ b/k2hpx_unload_hash_library.md
@@ -17,9 +17,11 @@ next_string: k2hpx_unload_transaction_library
 Removes the user-defined hash library
 
 ## Description
+
 ```
 bool k2hpx_unload_hash_library ( void )
 ```
+
 Removes the user-defined hash library that is added by k2hpx_load_hash_library. 
 
 ## Parameters
@@ -30,15 +32,19 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Removes the user-defined hash library
+
 ```
 <?php
 var_dump(k2hpx_unload_hash_library());
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+
 
 ## See Also
 - [k2hpx_load_hash_library](k2hpx_load_hash_library.html) - Loads hash functions from the file

--- a/k2hpx_unload_hash_libraryja.md
+++ b/k2hpx_unload_hash_libraryja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_unload_transaction_library
 ハッシュ関数ライブラリを取り外す
 
 ## 説明
+
 ```
 bool k2hpx_unload_hash_library ( void )
 ```
+
 k2hpx_load_hash_libraryでロードした共有ライブラリファイルを取り外します。 
 
 ## パラメータ
@@ -30,15 +32,19 @@ k2hpx_load_hash_libraryでロードした共有ライブラリファイルを取
 
 ## 例
 - 例 1 - ハッシュ関数用ライブラリを取り外す
+
 ```
 <?php
 var_dump(k2hpx_unload_hash_library());
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+
 
 ## 参考
 - [k2hpx_load_hash_library](k2hpx_load_hash_libraryja.html) - ハッシュ関数を有効にする

--- a/k2hpx_unload_transaction_library.md
+++ b/k2hpx_unload_transaction_library.md
@@ -17,9 +17,11 @@ next_string: k2hpx_unset_debug_file
 Removes the user-defined transaction library
 
 ## Description
+
 ```
 bool k2hpx_unload_transaction_library ( void )
 ```
+
 Removes the user-defined transaction library that is added by [k2hpx_load_transaction_library](k2hpx_load_transaction_library.html). 
 
 ## Parameters
@@ -30,15 +32,19 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Removes the user-defined transaction library
+
 ```
 <?php
 var_dump(k2hpx_unload_transaction_library());
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 ```
+
 
 ## See Also
 - [k2hpx_load_transaction_library](k2hpx_load_transaction_library.html) - Loads functions of k2hash transaction usage from the file

--- a/k2hpx_unload_transaction_libraryja.md
+++ b/k2hpx_unload_transaction_libraryja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_unset_debug_file
 トランザクション用ライブラリを無効にする
 
 ## 説明
+
 ```
 bool k2hpx_unload_transaction_library ( void )
 ```
+
 [k2hpx_load_transaction_library](k2hpx_load_transaction_libraryja.html) で読み込んだトランザクション用ライブラリを無効にします。
 
 ## パラメータ
@@ -30,15 +32,19 @@ bool k2hpx_unload_transaction_library ( void )
 
 ## 例
 - 例 1 - トランザクション用ライブラリを読み込む
+
 ```
 <?php
 var_dump(k2hpx_unload_transaction_library());
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 ```
+
 
 ## 参考
 - [k2hpx_load_transaction_library](k2hpx_load_transaction_libraryja.html) - トランザクション用ライブラリを読み込む

--- a/k2hpx_unset_debug_file.md
+++ b/k2hpx_unset_debug_file.md
@@ -17,9 +17,11 @@ next_string: k2hpx_unset_transaction_thread_pool
 Set log output  to stderr
 
 ## Description
+
 ```
 void k2hpx_unset_debug_file ( void )
 ```
+
 Set log output  to stderr.
 
 ## Parameters
@@ -27,15 +29,19 @@ This function has no parameters.
 
 ## Examples
 - Example 1 - Set log output  to stderr
+
 ```
 <?php
 var_dump(k2hpx_unset_debug_file());
 ?>
 ```
+
 The above example will output:
+
 ```
 NULL
 ```
+
 
 ## See Also
 - [k2hpx_bump_debug_level](k2hpx_bump_debug_level.html) - Changes the log level

--- a/k2hpx_unset_debug_fileja.md
+++ b/k2hpx_unset_debug_fileja.md
@@ -17,9 +17,11 @@ next_string: k2hpx_unset_transaction_thread_pool
 ログ出力先を標準エラーに指定する
 
 ## 説明
+
 ```
 void k2hpx_unset_debug_file ( void )
 ```
+
 ログ出力先を標準エラーに指定します。 
 
 ## パラメータ
@@ -27,16 +29,20 @@ void k2hpx_unset_debug_file ( void )
 
 ## 例
 - 例 1 - ログ出力先を標準エラーにする
+
 ```
 <?php
 var_dump(k2hpx_unset_debug_file());
 ?>
 
 ```
+
 上の例の出力は以下となります。
+
 ```
 NULL
 ```
+
 
 ## 参考
 - [k2hpx_bump_debug_level](k2hpx_bump_debug_levelja.html) - ログレベルを変更する

--- a/k2hpx_unset_transaction_thread_pool.md
+++ b/k2hpx_unset_transaction_thread_pool.md
@@ -17,9 +17,11 @@ next_string:
 Stops transaction workers
 
 ## Description
+
 ```
 bool k2hpx_unset_transaction_thread_pool ( void )
 ```
+
 Stops transaction workers. 
 
 ## Parameters

--- a/k2hpx_unset_transaction_thread_poolja.md
+++ b/k2hpx_unset_transaction_thread_poolja.md
@@ -17,9 +17,11 @@ next_string:
 トランザクション処理用のスレッドを利用しない
 
 ## 説明
+
 ```
 bool k2hpx_unset_transaction_thread_pool ( void )
 ```
+
 トランザクション処理用のスレッドを利用しません。 
 
 ## パラメータ

--- a/k2hq_class.md
+++ b/k2hq_class.md
@@ -18,6 +18,7 @@ K2hQueue represents a queue that holds values by using [K2HASH](https://k2hash.a
 Elements in K2hQueue are ordered in FIFO of LIFO manner. 
 
 ## Class overview
+
 ```
 K2hQueue {
     public intfalsecount ( void )
@@ -29,6 +30,7 @@ K2hQueue {
     public remove ( int $count [, string $pass ] ) : bool
 }
 ```
+
 
 ## Method list
 

--- a/k2hq_class.md
+++ b/k2hq_class.md
@@ -37,7 +37,7 @@ K2hQueue {
 - [K2hQueue::__construct](k2hq_construct.html) - Creates a K2hQueue instance
 - [K2hQueue::count](k2hq_count.html) - Counts elements in the K2hQueue object
 - [K2hQueue::dump](k2hq_dump.html) - Prints the elements in the K2hQueue object
-- [K2hQueue::isEmpty](k2hq_isEmpty.html) - Returns whether the K2hQueue is empty
+- [K2hQueue::isEmpty](k2hq_isempty.html) - Returns whether the K2hQueue is empty
 - [K2hQueue::pop](k2hq_pop.html) - Removes and returns the removed element from the K2hQueue
 - [K2hQueue::push](k2hq_push.html) - Adds a value to the K2hQueue
 - [K2hQueue::read](k2hq_read.html) - Returns a key/value pair from the K2hQueue

--- a/k2hq_classja.md
+++ b/k2hq_classja.md
@@ -34,11 +34,10 @@ K2hQueue {
 
 
 ## メソッド一覧
-
 - [K2hQueue::__construct](k2hq_constructja.html) - 新しいK2hQueueオブジェクトを作成する
 - [K2hQueue::count](k2hq_countja.html) - キューにある要素の数を取得する
 - [K2hQueue::dump](k2hq_dumpja.html) - キューにある要素を表示する
-- [K2hQueue::isEmpty](k2hq_isEmptyja.html) - キューが空かどうかを判定する
+- [K2hQueue::isEmpty](k2hq_isemptyja.html) - キューが空かどうかを判定する
 - [K2hQueue::pop](k2hq_popja.html) - キューから要素を取得する
 - [K2hQueue::push](k2hq_pushja.html) - キューに要素を追加する
 - [K2hQueue::read](k2hq_readja.html) - キューの要素を表示する

--- a/k2hq_classja.md
+++ b/k2hq_classja.md
@@ -19,6 +19,7 @@ K2hQueueクラスは、[K2HASH](https://k2hash.antpick.ax/indexja.html)を利用
 データの取り出し方法は、先入先出し（FIFO）、後入れ先出し（LIFO）を指定できます。
 
 ## Class 概要
+
 ```
 K2hQueue {
     public intfalsecount ( void )
@@ -30,6 +31,7 @@ K2hQueue {
     public remove ( int $count [, string $pass ] ) : bool
 }
 ```
+
 
 ## メソッド一覧
 

--- a/k2hq_construct.md
+++ b/k2hq_construct.md
@@ -17,9 +17,11 @@ next_string: K2hQueue::count
 Creates a K2hQueue instance
 
 ## Description
+
 ```
 public K2hQueue::__construct ( mixed $handle_res [, bool $is_fifo [, string $prefix ]] )
 ```
+
 Creates a [K2hQueue](k2hq_class.html) instance. 
 
 ## Parameters
@@ -32,6 +34,7 @@ Specifies the prefix of the [K2hQueue](k2hq_class.html).
 
 ## Examples
 - Example 1 - Creates a [K2hQueue](k2hq_class.html) instance
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -45,13 +48,16 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 int(0)
 int(1)
 string(15) "test_queue_data"
 int(0)
 ```
+
 
 ## See Also
 - [K2hash::getQueue](k2h_getqueue.html) - Gets a K2hQueue object

--- a/k2hq_constructja.md
+++ b/k2hq_constructja.md
@@ -17,9 +17,11 @@ next_string: K2hQueue::count
 新しいK2hQueueオブジェクトを作成する
 
 ## 説明
+
 ```
 public K2hQueue::__construct ( mixed $handle_res [, bool $is_fifo [, string $prefix ]] )
 ```
+
 新しい[K2hQueue](k2hq_classja.html)オブジェクトを作成します。 
 
 ## パラメータ
@@ -32,6 +34,7 @@ FIFO(先入先出し)キューならtrue、そうでなければ、false
 
 ## 例
 - 例 1 - キューからデータを取り出す
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -45,13 +48,16 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 int(0)
 int(1)
 string(15) "test_queue_data"
 int(0)
 ```
+
 
 ## 参考
 - [K2hash::getQueue](k2h_getqueueja.html) - K2hQueueオブジェクトを取得する

--- a/k2hq_count.md
+++ b/k2hq_count.md
@@ -17,9 +17,11 @@ next_string: K2hQueue::dump
 Counts elements in the K2hQueue object
 
 ## Description
+
 ```
 public intfalseK2hQueue::count ( void )
 ```
+
 Counts the number of elements in the [K2hQueue](k2hq_class.html) object. 
 
 ## Parameters
@@ -30,6 +32,7 @@ Returns the number of elements in the [K2hQueue](k2hq_class.html).
 
 ## Examples
 - Example 1 - Gets a element from [K2hQueue](k2hq_class.html)
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -43,13 +46,16 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 int(0)
 int(1)
 string(15) "test_queue_data"
 int(0)
 ```
+
 
 ## See Also
 - [K2hQueue::pop](k2hq_pop.html) - Removes and returns the removed element from the K2hQueue

--- a/k2hq_countja.md
+++ b/k2hq_countja.md
@@ -17,9 +17,11 @@ next_string: K2hQueue::dump
 キューにある要素の数を取得する
 
 ## 説明
+
 ```
 public intfalseK2hQueue::count ( void )
 ```
+
 キューにある要素の数を取得します。 
 
 ## パラメータ
@@ -30,6 +32,7 @@ public intfalseK2hQueue::count ( void )
 
 ## 例
 - 例 1 - キューからデータを取り出す
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -43,13 +46,16 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 int(0)
 int(1)
 string(15) "test_queue_data"
 int(0)
 ```
+
 
 ## 参考
 - [K2hQueue::pop](k2hq_popja.html) - キューから要素を取得する

--- a/k2hq_dump.md
+++ b/k2hq_dump.md
@@ -17,9 +17,11 @@ next_string: K2hQueue::isEmpty
 Prints the elements in the K2hQueue object
 
 ## Description
+
 ```
 public bool K2hQueue::dump ([ mixed $output ] )
 ```
+
 Gets the elements in the [K2hQueue](k2hq_class.html) object. 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Prints elements in the [K2hQueue](k2hq_class.html) object
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -53,7 +56,9 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 MARKER(test_queue_MARKER)= {
@@ -62,3 +67,4 @@ MARKER(test_queue_MARKER)= {
 }
 [0]                    = test_queue_000000000000758C_0000000061D9E5C9_0000000006108B76
 ```
+

--- a/k2hq_dumpja.md
+++ b/k2hq_dumpja.md
@@ -17,9 +17,11 @@ next_string: K2hQueue::isEmpty
 キューにある要素を表示する
 
 ## 説明
+
 ```
  public bool K2hQueue::dump ([ mixed $output ] )
 ```
+
 キューにある要素を表示します。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ next_string: K2hQueue::isEmpty
 
 ## 例
 - 例 1 - キューを表示する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -53,7 +56,9 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 MARKER(test_queue_MARKER)= {
@@ -62,3 +67,4 @@ MARKER(test_queue_MARKER)= {
 }
 [0]                    = test_queue_000000000000758C_0000000061D9E5C9_0000000006108B76
 ```
+

--- a/k2hq_isempty.md
+++ b/k2hq_isempty.md
@@ -17,9 +17,11 @@ next_string: K2hQueue::pop
 Returns whether the K2hQueue is empty
 
 ## Description
+
 ```
  public bool K2hQueue::isEmpty ( void )
 ```
+
 Returns where the [K2hQueue](k2hq_class.html) is empty. 
 
 ## Parameters
@@ -30,6 +32,7 @@ Returns true if the [K2hQueue](k2hq_class.html) object is empty, otherwise false
 
 ## Examples
 - Example 1 - Gets an element of a [K2hQueue](k2hq_class.html) instance
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -43,10 +46,13 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 bool(false)
 string(15) "test_queue_data"
 bool(true)
 ```
+

--- a/k2hq_isemptyja.md
+++ b/k2hq_isemptyja.md
@@ -17,9 +17,11 @@ next_string: K2hQueue::pop
 キューが空かどうかを判定する
 
 ## 説明
+
 ```
  public bool K2hQueue::isEmpty ( void )
 ```
+
 キューが空かどうかを判定します。 
 
 ## パラメータ
@@ -30,6 +32,7 @@ next_string: K2hQueue::pop
 
 ## 例
 - 例 1 - キューからデータを取り出す
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -43,10 +46,13 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 bool(false)
 string(15) "test_queue_data"
 bool(true)
 ```
+

--- a/k2hq_pop.md
+++ b/k2hq_pop.md
@@ -17,9 +17,11 @@ next_string: K2hQueue::push
 Removes and returns the removed element from the K2hQueue
 
 ## Description
+
 ```
  public stringfalseK2hQueue::pop ([ string $pass ] )
 ```
+
 Removes and gets the removed element from the [K2hQueue](k2hq_class.html). 
 
 ## Parameters
@@ -31,6 +33,7 @@ Returns a value.
 
 ## Examples
 - Example 1 - Gets a value from a [K2hQueue](k2hq_class.html) instance
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -41,13 +44,16 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 array(2) {
   [0]=>
   string(16) "test_queue_value"
 }
 ```
+
 
 ## See Also
 - [K2hQueue::push](k2hq_push.html) - Adds a value to the K2hQueue

--- a/k2hq_popja.md
+++ b/k2hq_popja.md
@@ -17,9 +17,11 @@ next_string: K2hQueue::push
 キューから要素を取得する
 
 ## 説明
+
 ```
 public stringfalseK2hQueue::pop ([ string $pass ] )
 ```
+
 キューから要素を取得します。 
 
 ## パラメータ
@@ -31,6 +33,7 @@ public stringfalseK2hQueue::pop ([ string $pass ] )
 
 ## 例
 - 例 1 - キューから要素を取得する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -41,13 +44,16 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 array(2) {
   [0]=>
   string(16) "test_queue_value"
 }
 ```
+
 
 ## 参考
 - [K2hQueue::push](k2hq_push.html) - Adds a value to the K2hQueue

--- a/k2hq_popja.md
+++ b/k2hq_popja.md
@@ -56,6 +56,6 @@ array(2) {
 
 
 ## 参考
-- [K2hQueue::push](k2hq_push.html) - Adds a value to the K2hQueue
-- [K2hQueue::read](k2hq_read.html) - Returns a key/value pair from the K2hQueue
-- [K2hQueue::remove](k2hq_remove.html) - Removes a value from the K2hQueue
+- [K2hQueue::push](k2hq_pushja.html) - キューに要素を追加する
+- [K2hQueue::read](k2hq_readja.html) - キューの要素を表示する
+- [K2hQueue::remove](k2hq_removeja.html) - キューから要素を削除する

--- a/k2hq_push.md
+++ b/k2hq_push.md
@@ -17,9 +17,11 @@ next_string: K2hQueue::read
 Adds a value to the K2hQueue
 
 ## Description
+
 ```
  public bool K2hQueue::push ( string $datavalue [, string $pass [, int $expire ]] )
 ```
+
 Adds a value to the [K2hQueue](k2hq_class.html). 
 
 ## Parameters
@@ -35,6 +37,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Adds a value to a [K2hQueue](k2hq_class.html) instance
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -45,11 +48,14 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 bool(true)
 string(16) "test_queue_value"
 ```
+
 
 ## See Also
 - [K2hQueue::pop](k2hq_pop.html) - Removes and returns the removed element from the K2hQueue

--- a/k2hq_pushja.md
+++ b/k2hq_pushja.md
@@ -58,6 +58,6 @@ string(16) "test_queue_value"
 
 
 ## 参考
-- [K2hQueue::pop](k2hq_pop.html) - Removes and returns the removed element from the K2hQueue
-- [K2hQueue::read](k2hq_read.html) - Returns a key/value pair from the K2hQueue
-- [K2hQueue::remove](k2hq_remove.html) - Removes a value from the K2hQueue
+- [K2hQueue::pop](k2hq_popja.html) - キューから要素を取得する
+- [K2hQueue::read](k2hq_readja.html) - キューの要素を表示する
+- [K2hQueue::remove](k2hq_removeja.html) - キューから要素を削除する

--- a/k2hq_pushja.md
+++ b/k2hq_pushja.md
@@ -17,9 +17,11 @@ next_string: K2hQueue::read
 キューに要素を追加する
 
 ## 説明
+
 ```
  public bool K2hQueue::push ( string $datavalue [, string $pass [, int $expire ]] )
 ```
+
 キューに要素を追加します。
 
 ## パラメータ
@@ -35,6 +37,7 @@ next_string: K2hQueue::read
 
 ## 例
 - 例 1 - キューの要素を表示する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -45,11 +48,14 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 bool(true)
 string(16) "test_queue_value"
 ```
+
 
 ## 参考
 - [K2hQueue::pop](k2hq_pop.html) - Removes and returns the removed element from the K2hQueue

--- a/k2hq_read.md
+++ b/k2hq_read.md
@@ -17,9 +17,11 @@ next_string: K2hQueue::remove
 Returns a key/value pair from the K2hQueue
 
 ## Description
+
 ```
 public stringfalseK2hQueue::read ([ int $pos [, string $pass ]] )
 ```
+
 Returns a value from the [K2hQueue](k2hq_class.html). This operation will not remove the value from the [K2hQueue](k2hq_class.html). 
 
 ### Note
@@ -36,6 +38,7 @@ Returns a value.
 
 ## Examples
 - Example 1 - Gets a value from a [K2hQueue](k2hq_class.html) instnace
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,10 +49,13 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 string(16) "test_queue_value"
 ```
+
 
 ## See Also
 - [K2hQueue::pop](k2hq_pop.html) - Removes and returns the removed element from the K2hQueue

--- a/k2hq_readja.md
+++ b/k2hq_readja.md
@@ -17,9 +17,11 @@ next_string: K2hQueue::remove
 キューの要素を表示する
 
 ## 説明
+
 ```
 public stringfalseK2hQueue::read ([ int $pos [, string $pass ]] )
 ```
+
 キューの要素を表示します。 
 
 ### 注意
@@ -36,6 +38,7 @@ public stringfalseK2hQueue::read ([ int $pos [, string $pass ]] )
 
 ## 例
 - 例 1 - キューの要素を表示する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,10 +49,13 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 string(16) "test_queue_value"
 ```
+
 
 ## 参考
 - [K2hQueue::pop](k2hq_popja.html) - キューから要素を取得する

--- a/k2hq_remove.md
+++ b/k2hq_remove.md
@@ -17,9 +17,11 @@ next_string:
 Removes a value from the K2hQueue
 
 ## Description
+
 ```
  public bool K2hQueue::remove ( int $count [, string $pass ] )
 ```
+
 Removes a value from the [K2hQueue](k2hq_class.html). 
 
 ## Parameters
@@ -33,6 +35,7 @@ Returns true on success or false on failure.
 
 ## Examples
 - Example 1 - Remove value from queue
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,12 +49,15 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 The above example will output:
+
 ```
 int(2)
 bool(true)
 int(1)
 ```
+
 
 ## See Also
 - [K2hQueue::pop](k2hq_pop.html) - Removes and returns the removed element from the K2hQueue

--- a/k2hq_removeja.md
+++ b/k2hq_removeja.md
@@ -17,9 +17,11 @@ next_string:
 キューから要素を削除する
 
 ## 説明
+
 ```
  public bool K2hQueue::remove ( int $count [, string $pass ] )
 ```
+
 キューから要素を削除します。 
 
 ## パラメータ
@@ -33,6 +35,7 @@ next_string:
 
 ## 例
 - 例 1 - キューの要素を削除する
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -46,12 +49,15 @@ unset($k2hqueue);
 k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は以下となります。
+
 ```
 int(2)
 bool(true)
 int(1)
 ```
+
 
 ## 参考
 - [K2hQueue::pop](k2hq_popja.html) - キューから要素を取得する

--- a/usage.md
+++ b/usage.md
@@ -27,6 +27,7 @@ You can easily register the repository by following the steps at [here](https://
 After registering the repository, install the K2HASH PHP Extension.  
 
 Debian based Linux users can install it by following the steps below:
+
 ```
 $ sudo apt-get update -y
 
@@ -39,7 +40,9 @@ $ sudo update-alternatives --set php /usr/bin/php8.1
 $ sudo apt-get install -y k2hash php-pecl-k2hash
 ```
 
+
 Fedora derived RPM based Linux(Fedora, CentOS, CentOS Stream, RHEL, etc.) users can install it by following the steps below:
+
 ```
 $ sudo dnf update -y
 
@@ -52,8 +55,10 @@ $ sudo dnf module install php:remi-8.1
 $ sudo dnf install -y php-pecl-k2hash
 ```
 
+
 ## 2. Test Execution
 Please create the following file and check whether file creation, key and value writing and reading are possible.
+
 ```
 <?php
 $handle = k2hpx_open_mem();
@@ -71,6 +76,7 @@ echo "OK";
 ?>
 ```
 
+
 ## 3. Importing and Executing
 Load and use the K2HASH PHP Extension as described in [PHP](https://www.php.net/).  
 If you installed the package, `k2hash.ini` is included in the package and you can use it immediately.  
@@ -80,6 +86,7 @@ Below is an example of PHP source code using some K2HASH PHP Extensions.
 The first example shows how to set a key with a value and get it. The second one shows set a key with a subkey with a value and get it. 
 
 ### Example 1 - Adds a key/value pair
+
 ```
 <?php
     // k2hpx_set_debug_level_message();
@@ -95,12 +102,16 @@ The first example shows how to set a key with a value and get it. The second one
 
 ?>
 ```
+
 The above example will output something similar to:
+
 ```
 string(5) "value"
 ```
 
+
 ### Example 2 - Adds a key with a subkey
+
 ```
 <?php
     // set subkeys & get subkeys
@@ -115,7 +126,9 @@ string(5) "value"
     k2hpx_close($handle);
 ?>
 ```
+
 The above example will output something similar to:
+
 ```
 array(3) {
   [0]=>
@@ -126,3 +139,4 @@ array(3) {
   string(7) "subkey3"
 }
 ```
+

--- a/usageja.md
+++ b/usageja.md
@@ -28,6 +28,7 @@ K2HASH PHP Extension のパッケージは、[AntPickax packagecloud.io](https:/
 
 
 DebianベースのLinuxユーザは、下の手順でインストールできます。
+
 ```
 $ sudo apt-get update -y
 
@@ -40,7 +41,9 @@ $ sudo update-alternatives --set php /usr/bin/php8.1
 $ sudo apt-get install -y k2hash php-pecl-k2hash
 ```
 
+
 Fedora派生のRPMベースのLinux(Fedora, CentOS, CentOS Stream, RHELなど)ユーザは、下の手順でインストールできます。
+
 
 ```
 $ sudo dnf update -y
@@ -54,8 +57,10 @@ $ sudo dnf module install php:remi-8.1
 $ sudo dnf install -y php-pecl-k2hash
 ```
 
+
 ## 2. 実行テスト
 以下のようなファイルを作成し、ファイル作成、キーと値の書き込み、読み出しができるか確認してみてください。  
+
 ```
 <?php
     $handle = k2hpx_open_mem();
@@ -73,6 +78,7 @@ $ sudo dnf install -y php-pecl-k2hash
 ?>
 ```
 
+
 ## 3. ロード・実行
 [PHP](https://www.php.net/) の説明に従って、K2HASH PHP Extensionをロードして使ってください。  
 パッケージでK2HASH PHP Extensionをインストールした場合、`k2hash.ini` が含まれており、すぐに利用できます。  
@@ -82,6 +88,7 @@ $ sudo dnf install -y php-pecl-k2hash
 一つ目の例では、値を持ったキーを保存し、それを取得しています。 二つ目の例では、子供のキーを持ったキーを保存し、それを取得しています。  
 
 ### 例 1 - K2hashサンプルコード
+
 ```
 <?php
     // k2hpx_set_debug_level_message();
@@ -97,12 +104,16 @@ $ sudo dnf install -y php-pecl-k2hash
 
 ?>
 ```
+
 上の例の出力は、 たとえば以下のようになります。
+
 ```
 string(5) "value"
 ```
 
+
 ### 例 2 - K2hashサンプルコード
+
 ```
 <?php
     // set subkeys & get subkeys
@@ -117,7 +128,9 @@ string(5) "value"
     k2hpx_close($handle);
 ?>
 ```
+
 上の例の出力は、 たとえば以下のようになります。
+
 ```
 array(3) {
   [0]=>
@@ -128,3 +141,4 @@ array(3) {
   string(7) "subkey3"
 }
 ```
+


### PR DESCRIPTION
#### Relevant Issue (if applicable)
n/a

#### Details
- Fixed markdown files for jekyll conversion fails and dead links
- Fixed a mistake in the link URL
