### PR TITLE
Fixed building and packaging script, etc for Ubuntu.

### DIFF
--- a/.github/workflows/publish_packages.sh
+++ b/.github/workflows/publish_packages.sh
@@ -81,6 +81,11 @@ prn_success()
 	echo "${CBLD}${CGRN}${CREV}[SUCCESS]${CDEF} $*"
 	echo ""
 }
+prn_message()
+{
+	echo "${CBLD}${CREV}[MESSAGE]${CDEF} $*"
+	echo ""
+}
 prn_fauilure()
 {
 	echo "${CBLD}${CRED}${CREV}[FAILURE]${CDEF} ${CRED}$*${CDEF}"
@@ -187,8 +192,7 @@ if [ -z "${PKG_EXT}" ]; then
 	exit 1
 fi
 if [ -z "${PC_TOKEN}" ]; then
-	prn_fauilure "\"--packagecloudio-token(-pctoken)\" option is not specified."
-	exit 1
+	prn_message "\"--packagecloudio-token(-pctoken)\" option is not specified, so do not publish a package."
 fi
 if [ -z "${PC_OWNER}" ]; then
 	PC_OWNER="antpickax"

--- a/buildutils/debian_build.sh
+++ b/buildutils/debian_build.sh
@@ -174,6 +174,13 @@ cd "${SRCTOP}" || exit 1
 # Check untracked files
 #----------------------------------------------------------
 prn_title "Check untracked files"
+
+# [NOTE]
+# When using actions/checkout@v1, suppress the following errors.
+# "Error: fatal: unsafe repository ('...' is owned by someone else)"
+#
+git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
 if [ -n "$(git status --untracked-files=no --porcelain 2>&1)" ]; then
 	prn_fauilure "Some files are untracked."
 	exit 1


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
When using `actions/checkout@v1`, the following error is now generated on Ubuntu.
```
Error: fatal: unsafe repository ('...' is owned by someone else)
```
To avoid this, the building script is modified.

And modified the packaging script.
