### PR TITLE
Resolved packaging error on debian

### DIFF
--- a/buildutils/rules.in
+++ b/buildutils/rules.in
@@ -50,6 +50,15 @@ build-%:
 debian/control: debian/control.in
 	/usr/share/dh-php/gen-control
 
+# [NOTE] 2023/9
+# Because updated pkg-pecl.mk, the "-a" option is added when calling gen-control.
+# If this "-a" option is given, an error will occur, so do not add the "-a" option
+# as before the update.
+#
+override_dh_clean:
+	dh_clean
+	/usr/share/dh-php/gen-control
+
 #
 # Local variables:
 # tab-width: 4


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
An error occurred during the packaging process on `debian` systems, so I took a countermeasure.
The error depended on updating `pkg-pecl.mk` and was caused by the option `-a` being given to `gen-control`.
The problem was resolved by additionally overriding `override_dh_clean` in `rules.in.in`.