### PR TITLE
Updated support OSs(unsupported ubuntu 18.04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,15 +61,15 @@ jobs:
         container:
           - ubuntu:22.04
           - ubuntu:20.04
-          - ubuntu:18.04
+          - debian:bookworm
           - debian:bullseye
           - debian:buster
-          - centos:centos7
           - rockylinux:9
           - rockylinux:8
+          - centos:centos7
           - fedora:37
           - fedora:36
-          - alpine:3.17
+          - alpine:3.18
 
         php:
           - PHP80

--- a/.github/workflows/phpexttypevars.sh
+++ b/.github/workflows/phpexttypevars.sh
@@ -229,6 +229,32 @@ elif [ "${CI_OSTYPE}" = "ubuntu:18.04" ] || [ "${CI_OSTYPE}" = "ubuntu:bionic" ]
 
 	IS_OS_UBUNTU=1
 
+elif [ "${CI_OSTYPE}" = "debian:12" ] || [ "${CI_OSTYPE}" = "debian:bookworm" ]; then
+	DIST_TAG="debian/bookworm"
+	PKG_EXT="deb"
+	PKG_OUTPUT_DIR="packages"
+
+	INSTALLER_BIN="apt-get"
+	UPDATE_CMD="update"
+	UPDATE_CMD_ARG=""
+	INSTALL_CMD="install"
+	INSTALL_CMD_ARG=""
+	INSTALL_AUTO_ARG="-y"
+	INSTALL_QUIET_ARG="-qq"
+	INSTALL_PKG_LIST="git lintian debhelper pkg-config ruby-dev rubygems rubygems-integration procps shtool k2hash-dev"
+
+	INSTALL_PHP_PRE_ADD_REPO="ca-certificates apt-transport-https software-properties-common"
+	INSTALL_PHP_REPO="packages.sury.org/php"
+	INSTALL_PHP_REPO_GPG_URL="https://packages.sury.org/php/apt.gpg"
+	INSTALL_PHP_REPO_GPG_FILEPATH="/usr/share/keyrings/deb.sury.org-php.gpg"
+	INSTALL_PHP_PKG_LIST="dh-php php${PHPVER_WITHPERIOD} php${PHPVER_WITHPERIOD}-dev libapache2-mod-php${PHPVER_WITHPERIOD}"
+	INSTALL_PHP_OPT=""
+	INSTALL_PHP_POST_CONFIG="update-alternatives --set php-config /usr/bin/php-config${PHPVER_WITHPERIOD}"
+	INSTALL_PHP_POST_BIN="update-alternatives --set php /usr/bin/php${PHPVER_WITHPERIOD}"
+	SWITCH_PHP_COMMAND=""
+
+	IS_OS_DEBIAN=1
+
 elif [ "${CI_OSTYPE}" = "debian:11" ] || [ "${CI_OSTYPE}" = "debian:bullseye" ]; then
 	DIST_TAG="debian/bullseye"
 	PKG_EXT="deb"
@@ -400,8 +426,8 @@ elif [ "${CI_OSTYPE}" = "fedora:36" ]; then
 
 	IS_OS_FEDORA=1
 
-elif [ "${CI_OSTYPE}" = "alpine:3.17" ]; then
-	DIST_TAG="alpine/v3.17"
+elif [ "${CI_OSTYPE}" = "alpine:3.18" ]; then
+	DIST_TAG="alpine/v3.18"
 	PKG_EXT="apk"
 	PKG_OUTPUT_DIR="packages"
 

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ buildutils/copyright
 buildutils/rules
 buildutils/watch
 buildutils/upstream/metadata
+buildutils/APKBUILD.templ
 
 #
 # Directries


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
Updated supported OS.
- Supported Debian 12.
- Ubuntu 18.04 is no longer supported.
- Alpine 3.18 is now supported, 3.17 is no longer supported.